### PR TITLE
fix to camera streaming on start depending on server side modules

### DIFF
--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -508,6 +508,7 @@ class RobotSession:
         when requested from the platform, for example when a user accesses the
         navigation view.
         """
+
         def publish(image, width, height, ts):
             self.publish_camera_frame(
                 camera_id, image, int(width), int(height), int(ts)
@@ -523,7 +524,7 @@ class RobotSession:
         self.publish(
             self._get_robot_subtopic(subtopic=MQTT_SUBTOPIC_OUT_CMD),
             "resend_modules",
-            qos=1
+            qos=1,
         )
 
     def _send_robot_status(self, robot_status):

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -41,6 +41,7 @@ MQTT_SUBTOPIC_CUSTOM_DATA = "custom"
 MQTT_SUBTOPIC_CUSTOM_COMMAND = "custom_command"
 MQTT_SUBTOPIC_STATE = "state"
 MQTT_SUBTOPIC_CAMERA_V2 = "ros/camera2"
+MQTT_SUBTOPIC_OUT_CMD = "out_cmd"
 
 MQTT_TOPIC_ECHO = "echo"
 MQTT_NAV_GOAL_GOAL = "ros/loc/nav_goal"
@@ -141,6 +142,8 @@ class RobotSession:
 
         self.command_callbacks = []
         self.camera_streamers = {}
+        self.camera_streaming_on = False
+        self.camera_streaming_mutex = threading.Lock()
         self.message_handlers[MQTT_INITIAL_POSE] = self._handle_initial_pose
         self.message_handlers[MQTT_CUSTOM_COMMAND] = self._handle_custom_command
         self.message_handlers[MQTT_NAV_GOAL_GOAL] = self._handle_nav_goal
@@ -287,6 +290,8 @@ class RobotSession:
             topic=self._get_robot_subtopic(subtopic=MQTT_NAV_GOAL_GOAL)
         )
         self.client.subscribe(topic=self._get_robot_subtopic(subtopic=MQTT_IN_CMD))
+        # ask server to resend modules, so our state is consistent with the server side
+        self._resend_modules()
 
     def _on_message(self, client, userdata, msg):
         """MQTT client message callback.
@@ -408,13 +413,17 @@ class RobotSession:
 
     def _start_cameras_streaming(self):
         """Start streaming on all registered cameras"""
-        for s in self.camera_streamers.values():
-            s.start()
+        with self.camera_streaming_mutex:
+            self.camera_streaming_on = True
+            for s in self.camera_streamers.values():
+                s.start()
 
     def _stop_cameras_streaming(self):
         """Start streaming on all registered cameras"""
-        for s in self.camera_streamers.values():
-            s.stop()
+        with self.camera_streaming_mutex:
+            self.camera_streaming_on = False
+            for s in self.camera_streamers.values():
+                s.stop()
 
     def publish_camera_frame(self, camera_id, image, width, height, ts):
         """Publishes a camera frame"""
@@ -499,13 +508,23 @@ class RobotSession:
         when requested from the platform, for example when a user accesses the
         navigation view.
         """
-
         def publish(image, width, height, ts):
             self.publish_camera_frame(
                 camera_id, image, int(width), int(height), int(ts)
             )
 
         self.camera_streamers[camera_id] = CameraStreamer(camera, publish)
+        with self.camera_streaming_mutex:
+            if self.camera_streaming_on:
+                self.camera_streamers[camera_id].start()
+
+    def _resend_modules(self):
+        """Ask server to resend modules"""
+        self.publish(
+            self._get_robot_subtopic(subtopic=MQTT_SUBTOPIC_OUT_CMD),
+            "resend_modules",
+            qos=1
+        )
 
     def _send_robot_status(self, robot_status):
         """Sends robot online/offline status message.

--- a/inorbit_edge/tests/test_robot_session.py
+++ b/inorbit_edge/tests/test_robot_session.py
@@ -52,13 +52,20 @@ def test_robot_session_connect(mock_mqtt_client, mock_inorbit_api):
     assert robot_session.api_key == "apikey_123"
     assert robot_session.robot_api_key == "robot_apikey_123"
     # check publish state was called with the correct API key
-    robot_session.client.publish.assert_called_with(
+    robot_session.client.publish.assert_any_call(
         topic="r/id_123/state",
         payload="1|robot_apikey_123|{}.edgesdk_py|name_123".format(
             get_module_version()
         ),
         qos=1,
         retain=True,
+    )
+    # check resend modules is called
+    robot_session.client.publish.assert_any_call(
+        topic="r/id_123/out_cmd",
+        payload="resend_modules",
+        qos=1,
+        retain=False,
     )
 
 


### PR DESCRIPTION
This PR solves a couple of issues related to cameras streaming race conditions, particularly on start:

* Ask server to resend modules states on start
* Auto stream camera on registration if camera streaming is ON
