### PR TITLE
Move initialization of robot session to the factory instead of pool

### DIFF
--- a/inorbit_edge/tests/test_robot_session_factory.py
+++ b/inorbit_edge/tests/test_robot_session_factory.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from unittest.mock import MagicMock
+from paho.mqtt.client import MQTTMessage
 from inorbit_edge.robot import RobotSessionFactory
+from inorbit_edge.inorbit_pb2 import CustomScriptCommandMessage
 
 
 def test_robot_factory_build(mock_mqtt_client):
@@ -20,3 +23,44 @@ def test_robot_factory_build(mock_mqtt_client):
             robot_session.http_proxy is None,
         ]
     )
+
+
+def test_robot_session_executes_command_callback_on_message(
+    mock_mqtt_client, mock_inorbit_api
+):
+    # Mock command handler.
+    my_command_handler = MagicMock()
+    # Set command handler mock method's name as it's accessed by the RobotSession class
+    my_command_handler.configure_mock(**{"__name__": "my_command_handler"})
+
+    robot_session_factory = RobotSessionFactory(api_key="apikey_123")
+    robot_session_factory.register_command_callback(my_command_handler)
+
+    robot_session = robot_session_factory.build("id_123", "name_123")
+
+    # connect robot_session so it populates properties with API response data
+    robot_session.connect()
+    # manually execute on_connect callback so the ``custom_command_callback``
+    # callback gets registered
+    robot_session._on_connect(..., ..., ..., 0)
+
+    msg = MQTTMessage(topic=b"r/id_123/custom_command/script/command")
+    msg.payload = CustomScriptCommandMessage(
+        file_name="foo", arg_options=["a", "b"], execution_id="1"
+    ).SerializeToString()
+
+    robot_session._on_message(..., ..., msg)
+
+    my_command_handler.assert_called_once()
+    call_args, call_kwargs = my_command_handler.call_args_list[0]
+
+    # No kwargs are expected
+    assert not call_kwargs
+
+    [robot_id, command_name, command_args, command_options] = call_args
+    assert robot_id == "id_123"
+    assert command_name == "customCommand"
+    assert command_args == ["foo", ["a", "b"]]
+    assert callable(command_options["result_function"])
+    assert callable(command_options["progress_function"])
+    assert command_options["metadata"] == {}

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ test_requirements = [
     "pytest-raises>=0.11",
     "pyyaml>=6.0",
     "lark>=1.0.0",
-    "requests_mock>=1.9.3"
+    "requests_mock>=1.9.3",
 ]
 
 dev_requirements = [
@@ -46,7 +46,8 @@ requirements = [
     "paho_mqtt==1.6.1",
     "PySocks==1.7.1",
     "protobuf==3.19.3",
-    "certifi>=2021.10.8"
+    "certifi>=2021.10.8",
+    "deprecated==1.2.13"
 ]
 
 extra_requirements = {


### PR DESCRIPTION
Refactored initialization of robot session objects to be done by the factory instead of by the pool. Factory responsibility is exactly that, to create initialized objects, while the pool deals with storing existing sessions and avoiding creating multiple instances for the same robot.
