### PR TITLE
Stop camera stream when robot session disconnects

### DIFF
--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -147,6 +147,7 @@ class RobotSession:
         self.camera_streamers = {}
         self.camera_streaming_on = False
         self.camera_streaming_mutex = threading.Lock()
+
         self.message_handlers[MQTT_INITIAL_POSE] = self._handle_initial_pose
         self.message_handlers[MQTT_CUSTOM_COMMAND] = self._handle_custom_command
         self.message_handlers[MQTT_NAV_GOAL_GOAL] = self._handle_nav_goal
@@ -670,6 +671,7 @@ class RobotSession:
     def disconnect(self):
         """Ends session, disconnecting from cloud services"""
         self.logger.info("Ending robot session")
+        self._stop_cameras_streaming()
         self._send_robot_status(robot_status="0")
 
         # TODO: Unsubscribe from topics

--- a/inorbit_edge/tests/test_video.py
+++ b/inorbit_edge/tests/test_video.py
@@ -15,10 +15,10 @@ def test_robot_session_register_camera(mock_mqtt_client, mock_inorbit_api, mocke
     )
     robot_session.connect()
 
-    # TODO: Improve OpenCVCamera test. This `video_url` parameter causes an
-    # OpenCV exception "error: (-215:Assertion failed) !_filename.empty() in function 'open'"
-    # This is fine for the purpose of this test that is verify that the Capture and Camera
-    # stream threads stop when the robot session disconnects.
+    # TODO: Improve OpenCVCamera test. This `video_url` parameter causes an OpenCV
+    # exception "error: (-215:Assertion failed) !_filename.empty() in function 'open'"
+    # This is fine for the purpose of this test that is verify that the Capture and
+    # Camera stream threads stop when the robot session disconnects.
     opencv_camera = OpenCVCamera(None, rate=8, scaling=0.2, quality=35)
     robot_session.register_camera(CAMERA_ID, opencv_camera)
 
@@ -28,7 +28,9 @@ def test_robot_session_register_camera(mock_mqtt_client, mock_inorbit_api, mocke
     camera_stream_stop_spy = mocker.spy(camera_stream, "stop")
     opencv_camera_close_spy = mocker.spy(opencv_camera, "close")
     # Simulate cmd to start camera stream
-    robot_session._handle_in_cmd(f"load_module|{INORBIT_MODULE_CAMERAS}|{RUNLEVEL}".encode())
+    robot_session._handle_in_cmd(
+        f"load_module|{INORBIT_MODULE_CAMERAS}|{RUNLEVEL}".encode()
+    )
     # Override _is_disconnected method to simulate successful MQTT client disconnection
     robot_session._is_disconnected = lambda: True
     robot_session.disconnect()

--- a/inorbit_edge/tests/test_video.py
+++ b/inorbit_edge/tests/test_video.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from inorbit_edge.robot import RobotSession
+from inorbit_edge.video import OpenCVCamera
+from inorbit_edge.robot import INORBIT_MODULE_CAMERAS
+
+
+def test_robot_session_register_camera(mock_mqtt_client, mock_inorbit_api, mocker):
+    CAMERA_ID = "cam0"
+    RUNLEVEL = 0
+    opencv_camera = OpenCVCamera(None, rate=8, scaling=0.2, quality=35)
+
+    robot_session = RobotSession(
+        robot_id="id_123", robot_name="name_123", api_key="apikey_123"
+    )
+    robot_session.connect()
+    robot_session.register_camera(CAMERA_ID, opencv_camera)
+
+    # Register spies for test assertions
+    stop_cameras_streaming_spy = mocker.spy(robot_session, "_stop_cameras_streaming")
+    camera_stream_stop_spy = mocker.spy(robot_session.camera_streamers[CAMERA_ID], "stop")
+    opencv_camera_close_spy = mocker.spy(opencv_camera, "close")
+    # Simulate cmd to start camera stream
+    robot_session._handle_in_cmd(f"load_module|{INORBIT_MODULE_CAMERAS}|{RUNLEVEL}".encode())
+    # Override _is_disconnected method to simulate successful MQTT client disconnection
+    robot_session._is_disconnected = lambda: True
+    robot_session.disconnect()
+
+    stop_cameras_streaming_spy.assert_called_once()
+    camera_stream_stop_spy.assert_called_once()
+    opencv_camera_close_spy.assert_called_once()

--- a/inorbit_edge/video.py
+++ b/inorbit_edge/video.py
@@ -119,6 +119,7 @@ class CameraStreamer:
         self.camera = camera
         self.running = False
         self.mutex = threading.Lock()
+        self.thread = None
         self.publish_frame = publish_frame_callback
         self.must_stop = False
 
@@ -128,11 +129,13 @@ class CameraStreamer:
             self.must_stop = False
             if not self.running:
                 self.running = True
-                threading.Thread(target=self._run).start()
+                self.thread = threading.Thread(target=self._run)
+                self.thread.start()
 
     def stop(self):
         """Stops streaming video to the platform"""
         self.must_stop = True
+        self.thread.join()
 
     def _run(self):
         """This thread takes care of getting video from a camera at the desired rate,

--- a/inorbit_edge/video.py
+++ b/inorbit_edge/video.py
@@ -61,6 +61,7 @@ class OpenCVCamera(Camera):
         self.video_url = video_url
         self.capture = None
         self.capture_mutex = threading.Lock()
+        self.capture_thread = None
         self.running = False
         self.logger = logging.getLogger(__class__.__name__)
         self.rate = rate
@@ -74,15 +75,17 @@ class OpenCVCamera(Camera):
                 self.capture = cv2.VideoCapture(self.video_url)
             if not self.running:
                 self.running = True
-                threading.Thread(target=self._run).start()
+                self.capture_thread = threading.Thread(target=self._run)
+                self.capture_thread.start()
 
     def close(self):
         """Closes the capturing device / stream"""
         with self.capture_mutex:
+            self.running = False
+            self.capture_thread.join()
             if self.capture is not None:
                 self.capture.release()
                 self.capture = None
-            self.running = False
 
     def get_frame_jpg(self):
         """Returns the latest frame captured by the camera as JPG"""

--- a/inorbit_edge/video.py
+++ b/inorbit_edge/video.py
@@ -80,9 +80,10 @@ class OpenCVCamera(Camera):
 
     def close(self):
         """Closes the capturing device / stream"""
+        self.running = False
+        self.capture_thread.join()
+        self.logger.info("Waiting for the capture thread to finish")
         with self.capture_mutex:
-            self.running = False
-            self.capture_thread.join()
             if self.capture is not None:
                 self.capture.release()
                 self.capture = None

--- a/inorbit_edge/video.py
+++ b/inorbit_edge/video.py
@@ -81,8 +81,8 @@ class OpenCVCamera(Camera):
     def close(self):
         """Closes the capturing device / stream"""
         self.running = False
-        self.capture_thread.join()
         self.logger.info("Waiting for the capture thread to finish")
+        self.capture_thread.join()
         with self.capture_mutex:
             if self.capture is not None:
                 self.capture.release()
@@ -135,6 +135,7 @@ class CameraStreamer:
     def stop(self):
         """Stops streaming video to the platform"""
         self.must_stop = True
+        self.logger.info("Waiting for the streaming thread to finish")
         self.thread.join()
 
     def _run(self):

--- a/inorbit_edge/video.py
+++ b/inorbit_edge/video.py
@@ -116,6 +116,7 @@ class CameraStreamer:
     """Streams video from a camera to InOrbit"""
 
     def __init__(self, camera, publish_frame_callback):
+        self.logger = logging.getLogger(__class__.__name__)
         self.camera = camera
         self.running = False
         self.mutex = threading.Lock()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,12 @@ setup_requirements = [
     "pytest-runner>=5.2",
 ]
 
+video_requirements = [
+    "opencv-python==4.7.0.68"
+]
+
 test_requirements = [
+    *video_requirements,
     "black>=19.10b0",
     "codecov>=2.1.4",
     "flake8>=3.8.3",
@@ -26,14 +31,9 @@ test_requirements = [
     "requests_mock>=1.9.3",
 ]
 
-video_requirements = [
-    "opencv-python==4.7.0.68"
-]
-
 dev_requirements = [
     *setup_requirements,
     *test_requirements,
-    *video_requirements,
     "bump2version>=1.0.1",
     "coverage>=5.1",
     "ipython>=7.15.0",

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,14 @@ test_requirements = [
     "requests_mock>=1.9.3",
 ]
 
+video_requirements = [
+    "opencv-python==4.7.0.68"
+]
+
 dev_requirements = [
     *setup_requirements,
     *test_requirements,
+    *video_requirements,
     "bump2version>=1.0.1",
     "coverage>=5.1",
     "ipython>=7.15.0",
@@ -54,7 +59,7 @@ extra_requirements = {
     "setup": setup_requirements,
     "test": test_requirements,
     "dev": dev_requirements,
-    "video": ["opencv-python==4.7.0.68"],
+    "video": video_requirements,
     "all": [
         *requirements,
         *dev_requirements,


### PR DESCRIPTION
# Description

When the `RobotSession` disconnects it doesn't stop the camera stream, causing `CameraStream` main thread to try to publish MQTT messages after the connection to the broker has been closed.

## Changes
- Camera streams are now stopped when the `RobotSession` disconnects.
- `Camera` and `CameraStream` now wait for the main thread to finish when stopping/closing.
- Added basic test for video module.
- Modified `test` requirements to also include `video` requirements.