### PR TITLE
Add support for throttling based on keys when publishing key-values

### DIFF
--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -209,7 +209,7 @@ class RobotSession:
                 "last_ts": 0,
                 "min_time_between_calls": 1,  # seconds
             },
-            "publish_key_values": {}, # this supports key-level throttling
+            "publish_key_values": {},  # this supports key-level throttling
             "publish_odometry": {
                 "last_ts": 0,
                 "min_time_between_calls": 1,  # seconds

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -915,10 +915,10 @@ class RobotSession:
             else:
                 return str(value)
 
-        def set_pairs(key):
+        def set_pairs(k):
             item = KeyValueCustomElement()
-            item.key = key
-            item.value = convert_value(key_values[key])
+            item.key = k
+            item.value = convert_value(key_values[k])
             return item
 
         msg = CustomDataMessage()

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -209,10 +209,7 @@ class RobotSession:
                 "last_ts": 0,
                 "min_time_between_calls": 1,  # seconds
             },
-            "publish_key_values": {
-                "last_ts": 0,
-                "min_time_between_calls": 1,  # seconds
-            },
+            "publish_key_values": {}, # this supports key-level throttling
             "publish_odometry": {
                 "last_ts": 0,
                 "min_time_between_calls": 1,  # seconds
@@ -254,7 +251,7 @@ class RobotSession:
             robot_id=self.robot_id, subtopic=subtopic
         )
 
-    def _should_publish_message(self, method):
+    def _should_publish_message(self, method, key=None):
         """Determine if the method should be executed or not
 
         It uses robot session property ``self._publish_throttling`` to
@@ -264,12 +261,26 @@ class RobotSession:
 
         Args:
             method (str): method name.
+            key (str): key for supporting fine grained throttling.
 
         Returns:
             bool: True if the method can be called.
         """
         try:
             throttling_cfg = self._publish_throttling[method]
+            # If a throttling key is provided, add an additional level
+            # to the throttling configuration for that method and populate
+            # it with last_ts and min_time_between_calls.
+            # NOTE(lpineda.io): throttling by keys is dynamic, so they don't
+            # need to be defined on __init__.
+            # TODO(lpineda.io): add support for configuring min_time_between_calls 
+            if key:
+                if key not in self._publish_throttling[method]:
+                    self._publish_throttling[method][key] = {
+                        "last_ts": 0,
+                        "min_time_between_calls": 1,  # seconds
+                    }
+                throttling_cfg = self._publish_throttling[method][key]
         except KeyError:
             self.logger.error(
                 "Trying to publish using a method with no throttling configured."
@@ -898,11 +909,6 @@ class RobotSession:
             is_event (bool): Events are not throttled
         """
 
-        if not is_event and not self._should_publish_message(
-            method="publish_key_values"
-        ):
-            return None
-
         def convert_value(value):
             if isinstance(value, object):
                 return json.dumps(value)
@@ -918,7 +924,12 @@ class RobotSession:
         msg = CustomDataMessage()
         msg.custom_field = custom_field
 
-        msg.key_value_payload.pairs.extend(map(set_pairs, key_values.keys()))
+        for key in key_values.keys():
+            if not is_event and not self._should_publish_message(
+                method="publish_key_values", key=key
+            ):
+                pass
+            msg.key_value_payload.pairs.append(set_pairs(key))
 
         self.publish_protobuf(MQTT_SUBTOPIC_CUSTOM_DATA, msg)
 

--- a/inorbit_edge/tests/demo/example.py
+++ b/inorbit_edge/tests/demo/example.py
@@ -203,11 +203,18 @@ if __name__ == "__main__":
                     yaw=fake_robot.yaw,
                     frame_id=fake_robot.frame_id,
                 )
+                robot_session.publish_system_stats(
+                    cpu_load_percentage=random()
+                )
                 robot_session.publish_key_values(
                     {
                         "battery": fake_robot.battery,
                         "status": fake_robot.status,
-                        "cpu": fake_robot.cpu,
+                    }
+                )
+                robot_session.publish_key_values(
+                    {
+                        "foo": "bar",
                     }
                 )
                 robot_session.publish_odometry(
@@ -233,6 +240,8 @@ if __name__ == "__main__":
                     # Make ranges over threshold infinite
                     lidar = [inf if r >= 3 else r for r in lidar]
                     ranges.append(lidar)
+                # NOTE: for publishing laser scans the robot pose is needed.
+                # In that case, avoid using publish_pose method.
                 robot_session.publish_lasers(
                     x=fake_robot.x,
                     y=fake_robot.y,

--- a/inorbit_edge/tests/test_robot_session.py
+++ b/inorbit_edge/tests/test_robot_session.py
@@ -100,3 +100,15 @@ def test_method_throttling():
     assert not robot_session._should_publish_message(method="publish_pose")
     robot_session._publish_throttling["publish_pose"]["last_ts"] = 0
     assert robot_session._should_publish_message(method="publish_pose")
+
+    # Also test key based throttling
+    assert robot_session._should_publish_message(method="publish_key_values", key="foo")
+    assert not robot_session._should_publish_message(method="publish_key_values", key="foo")
+    robot_session._publish_throttling["publish_key_values"]["foo"]["last_ts"] = 0
+    assert robot_session._should_publish_message(method="publish_key_values", key="foo")
+
+    assert robot_session._should_publish_message(method="publish_key_values", key="bar")
+    assert not robot_session._should_publish_message(method="publish_key_values", key="bar")
+    robot_session._publish_throttling["publish_key_values"]["bar"]["last_ts"] = 0
+    assert robot_session._should_publish_message(method="publish_key_values", key="bar")
+

--- a/inorbit_edge/tests/test_robot_session.py
+++ b/inorbit_edge/tests/test_robot_session.py
@@ -103,12 +103,15 @@ def test_method_throttling():
 
     # Also test key based throttling
     assert robot_session._should_publish_message(method="publish_key_values", key="foo")
-    assert not robot_session._should_publish_message(method="publish_key_values", key="foo")
+    assert not robot_session._should_publish_message(
+        method="publish_key_values", key="foo"
+    )
     robot_session._publish_throttling["publish_key_values"]["foo"]["last_ts"] = 0
     assert robot_session._should_publish_message(method="publish_key_values", key="foo")
 
     assert robot_session._should_publish_message(method="publish_key_values", key="bar")
-    assert not robot_session._should_publish_message(method="publish_key_values", key="bar")
+    assert not robot_session._should_publish_message(
+        method="publish_key_values", key="bar"
+    )
     robot_session._publish_throttling["publish_key_values"]["bar"]["last_ts"] = 0
     assert robot_session._should_publish_message(method="publish_key_values", key="bar")
-


### PR DESCRIPTION
### Description

Fixes issue that caused key-values messages to drop when calling `publish_key_values` methods multiple times.

#### Demo

After consecutive calls to `publish_key_values` values are sent to the cloud

![image](https://github.com/inorbit-ai/edge-sdk-python/assets/8092356/015986ef-9dca-476f-a1f2-7184b8f4f3fc)
