### PR TITLE
Add `RobotSession.apply_footprint()`

### DIFF
--- a/inorbit_edge/models.py
+++ b/inorbit_edge/models.py
@@ -89,24 +89,31 @@ class RobotSessionModel(BaseModel):
     Attributes:
         robot_id (str): The unique ID of the robot
         robot_name (str): The name of the robot
-        robot_api_key (str | None, optional): The robot key for InOrbit cloud services
+        robot_key (str | None, optional): The robot key for InOrbit cloud services
         api_key (str | None, optional): The InOrbit API token
         use_ssl (bool, optional): If SSL is used for the InOrbit API connection
         endpoint (HttpUrl, optional): The URL of the API or inorbit_edge's
                                       INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL by default
+        rest_api_endpoint (HttpUrl, optional): The URL of the InOrbit REST API.
+                                               If None, RobotSession will load a
+                                               default value.
+        account_id (str, optional): The account ID of the robot owner. Required for
+                                    applying configurations to the robot.
     """
 
     robot_id: str
     robot_name: str
-    robot_api_key: Optional[str] = None
+    robot_key: Optional[str] = None
     api_key: Optional[str] = os.getenv("INORBIT_API_KEY")
     use_ssl: bool = os.environ.get("INORBIT_USE_SSL", "true").lower() == "true"
     endpoint: HttpUrl = os.environ.get(
         "INORBIT_API_URL", INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
     )
+    rest_api_endpoint: Optional[HttpUrl] = None
+    account_id: Optional[str] = None
 
     # noinspection PyMethodParameters
-    @field_validator("robot_id", "robot_name", "robot_api_key", "api_key")
+    @field_validator("robot_id", "robot_name", "robot_key", "api_key", "account_id")
     def check_whitespace(cls, value: str) -> str:
         """Check if the field contains whitespace.
 

--- a/inorbit_edge/models.py
+++ b/inorbit_edge/models.py
@@ -11,7 +11,7 @@ from typing import Optional
 from pydantic import BaseModel, AnyUrl, field_validator, HttpUrl
 
 # InOrbit
-from inorbit_edge.robot import INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
+from inorbit_edge.robot import INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL, INORBIT_REST_API_URL
 
 
 class CameraConfig(BaseModel):
@@ -85,6 +85,10 @@ class RobotSessionModel(BaseModel):
 
     * INORBIT_API_KEY (required): The InOrbit API key
     * INORBIT_USE_SSL: If SSL should be used (default is true)
+    * INORBIT_API_URL: The URL of the API (default is
+        inorbit_edge.robot.INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL)
+    * INORBIT_REST_API_URL: The URL of the InOrbit REST API (default is
+        inorbit_edge.robot.INORBIT_REST_API_URL)
 
     Attributes:
         robot_id (str): The unique ID of the robot
@@ -95,8 +99,7 @@ class RobotSessionModel(BaseModel):
         endpoint (HttpUrl, optional): The URL of the API or inorbit_edge's
                                       INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL by default
         rest_api_endpoint (HttpUrl, optional): The URL of the InOrbit REST API.
-                                               If None, RobotSession will load a
-                                               default value.
+                                               INORBIT_REST_API_URL by default.
         account_id (str, optional): The account ID of the robot owner. Required for
                                     applying configurations to the robot.
     """
@@ -109,7 +112,9 @@ class RobotSessionModel(BaseModel):
     endpoint: HttpUrl = os.environ.get(
         "INORBIT_API_URL", INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
     )
-    rest_api_endpoint: Optional[HttpUrl] = None
+    rest_api_endpoint: Optional[HttpUrl] = os.environ.get(
+        "INORBIT_REST_API_URL", INORBIT_REST_API_URL
+    )
     account_id: Optional[str] = None
 
     # noinspection PyMethodParameters

--- a/inorbit_edge/models.py
+++ b/inorbit_edge/models.py
@@ -93,7 +93,7 @@ class RobotSessionModel(BaseModel):
     Attributes:
         robot_id (str): The unique ID of the robot
         robot_name (str): The name of the robot
-        robot_key (str | None, optional): The robot key for InOrbit cloud services
+        robot_api_key (str | None, optional): The robot key for InOrbit cloud services
         api_key (str | None, optional): The InOrbit API token
         use_ssl (bool, optional): If SSL is used for the InOrbit API connection
         endpoint (HttpUrl, optional): The URL of the API or inorbit_edge's
@@ -106,7 +106,7 @@ class RobotSessionModel(BaseModel):
 
     robot_id: str
     robot_name: str
-    robot_key: Optional[str] = None
+    robot_api_key: Optional[str] = None
     api_key: Optional[str] = os.getenv("INORBIT_API_KEY")
     use_ssl: bool = os.environ.get("INORBIT_USE_SSL", "true").lower() == "true"
     endpoint: HttpUrl = os.environ.get(
@@ -118,7 +118,7 @@ class RobotSessionModel(BaseModel):
     account_id: Optional[str] = None
 
     # noinspection PyMethodParameters
-    @field_validator("robot_id", "robot_name", "robot_key", "api_key", "account_id")
+    @field_validator("robot_id", "robot_name", "robot_api_key", "api_key", "account_id")
     def check_whitespace(cls, value: str) -> str:
         """Check if the field contains whitespace.
 

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -694,7 +694,7 @@ class RobotSession:
             if self.camera_streaming_on:
                 self.camera_streamers[camera_id].start()
 
-    def set_robot_footprint(self, footprint: list, radius: float):
+    def set_robot_footprint(self, footprint: list = None, radius: float = None):
         """Creates and applies a RobotFootprint configuration at the robot level scope.
         Note that configurations can be applied at other scopes as well.
         Refer to the REST APIs documentation for more information.
@@ -725,8 +725,12 @@ class RobotSession:
                 "id": "all",
                 "scope": f"robot/{self.account_id}/{self.robot_id}",
             },
-            "spec": {"footprint": footprint, "radius": radius},
+            "spec": {}
         }
+        if footprint:
+            body["spec"]["footprint"] = footprint
+        if radius:
+            body["spec"]["radius"] = radius
 
         res = requests.post(
             f"{self.inorbit_rest_api_endpoint}/configuration/apply",

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -694,7 +694,7 @@ class RobotSession:
             if self.camera_streaming_on:
                 self.camera_streamers[camera_id].start()
 
-    def set_robot_footprint(self, footprint: list[dict], radius: float):
+    def set_robot_footprint(self, footprint: list, radius: float):
         """Creates and applies a RobotFootprint configuration at the robot level scope.
         Note that configurations can be applied at other scopes as well.
         Refer to the REST APIs documentation for more information.

--- a/inorbit_edge/tests/demo/example.py
+++ b/inorbit_edge/tests/demo/example.py
@@ -32,13 +32,14 @@ NUM_LASERS = 3
 ROBOT_FOOTPRINT = {
     "footprint": [
         {"x": -0.5, "y": -0.5},
-        {"x":  0.3, "y": -0.5},
-        {"x":  0.7, "y":  0.0},
-        {"x":  0.3, "y":  0.5},
-        {"x": -0.5, "y":  0.5},
+        {"x": 0.3, "y": -0.5},
+        {"x": 0.7, "y": 0.0},
+        {"x": 0.3, "y": 0.5},
+        {"x": -0.5, "y": 0.5},
     ],
-    "radius": 0.2
+    "radius": 0.2,
 }
+
 
 class FakeRobot:
     """Class that simulates robot data and generates random data"""

--- a/inorbit_edge/tests/demo/example.py
+++ b/inorbit_edge/tests/demo/example.py
@@ -9,7 +9,12 @@ import os
 import sys
 from math import inf
 
-from inorbit_edge.robot import RobotSessionFactory, RobotSessionPool, LaserConfig
+from inorbit_edge.robot import (
+    RobotSessionFactory,
+    RobotSessionPool,
+    LaserConfig,
+    RobotFootprintSpec,
+)
 from inorbit_edge.video import OpenCVCamera
 
 logging.basicConfig(
@@ -29,16 +34,16 @@ LIDAR_MAX = 3.2
 NUM_ROBOTS = 2
 NUM_LASERS = 3
 
-ROBOT_FOOTPRINT = {
-    "footprint": [
+ROBOT_FOOTPRINT = RobotFootprintSpec(
+    footprint=[
         {"x": -0.5, "y": -0.5},
         {"x": 0.3, "y": -0.5},
         {"x": 0.7, "y": 0.0},
         {"x": 0.3, "y": 0.5},
         {"x": -0.5, "y": 0.5},
     ],
-    "radius": 0.2,
-}
+    radius=0.2,
+)
 
 
 class FakeRobot:
@@ -183,8 +188,6 @@ if __name__ == "__main__":
         robot_session = robot_session_pool.get_session(
             robot_id=cur_robot_id, robot_name=cur_robot_id
         )
-        if ROBOT_FOOTPRINT:
-            robot_session.set_robot_footprint(**ROBOT_FOOTPRINT)
         fake_robot_pool[cur_robot_id] = FakeRobot(
             robot_id=cur_robot_id, robot_name=cur_robot_id
         )
@@ -207,6 +210,10 @@ if __name__ == "__main__":
                 )
             )
         robot_session.register_lasers(configs)
+
+        # Configure robot footprint
+        if ROBOT_FOOTPRINT:
+            robot_session.apply_footprint(ROBOT_FOOTPRINT)
 
     # Go through every fake robot and simulate robot movement
     while True:

--- a/inorbit_edge/tests/demo/example.py
+++ b/inorbit_edge/tests/demo/example.py
@@ -29,6 +29,16 @@ LIDAR_MAX = 3.2
 NUM_ROBOTS = 2
 NUM_LASERS = 3
 
+ROBOT_FOOTPRINT = {
+    "footprint": [
+        {"x": -0.5, "y": -0.5},
+        {"x":  0.3, "y": -0.5},
+        {"x":  0.7, "y":  0.0},
+        {"x":  0.3, "y":  0.5},
+        {"x": -0.5, "y":  0.5},
+    ],
+    "radius": 0.2
+}
 
 class FakeRobot:
     """Class that simulates robot data and generates random data"""
@@ -132,6 +142,7 @@ def my_command_handler(robot_id, command_name, args, options):
 if __name__ == "__main__":
     inorbit_api_endpoint = os.environ.get("INORBIT_URL")
     inorbit_api_url = os.environ.get("INORBIT_API_URL")
+    inorbit_account_id = os.environ.get("INORBIT_ACCOUNT_ID")
     inorbit_api_use_ssl = os.environ.get("INORBIT_USE_SSL")
     inorbit_api_key = os.environ.get("INORBIT_API_KEY")
 
@@ -144,14 +155,18 @@ if __name__ == "__main__":
     video_url = os.environ.get("INORBIT_VIDEO_URL")
 
     assert inorbit_api_endpoint, "Environment variable INORBIT_URL not specified"
-    assert inorbit_api_url, "Environment variable INORBIT_API_URL not specified"
     assert inorbit_api_key, "Environment variable INORBIT_API_KEY not specified"
+    # Required for setting configurations, such as robot footprints.
+    assert inorbit_api_url, "Environment variable INORBIT_API_URL not specified"
+    assert inorbit_account_id, "Environment variable INORBIT_ACCOUNT_ID not specified"
 
     # Create robot session factory and session pool
     robot_session_factory = RobotSessionFactory(
         endpoint=inorbit_api_endpoint,
+        rest_api_endpoint=inorbit_api_url,
         api_key=inorbit_api_key,
         use_ssl=inorbit_api_use_ssl == "true",
+        account_id=inorbit_account_id,
     )
     robot_session_factory.register_command_callback(log_command)
     robot_session_factory.register_command_callback(my_command_handler)
@@ -167,6 +182,8 @@ if __name__ == "__main__":
         robot_session = robot_session_pool.get_session(
             robot_id=cur_robot_id, robot_name=cur_robot_id
         )
+        if ROBOT_FOOTPRINT:
+            robot_session.set_robot_footprint(**ROBOT_FOOTPRINT)
         fake_robot_pool[cur_robot_id] = FakeRobot(
             robot_id=cur_robot_id, robot_name=cur_robot_id
         )

--- a/inorbit_edge/tests/test_models.py
+++ b/inorbit_edge/tests/test_models.py
@@ -94,7 +94,7 @@ class TestRobotSessionModel:
         return {
             "robot_id": "123",
             "robot_name": "test_robot",
-            "robot_api_key": "valid_robot_api_key",
+            "robot_key": "valid_robot_key",
             "api_key": "valid_api_key",
         }
 
@@ -102,7 +102,7 @@ class TestRobotSessionModel:
         model = RobotSessionModel(**base_model)
         assert model.robot_id == base_model["robot_id"]
         assert model.robot_name == base_model["robot_name"]
-        assert model.robot_api_key == base_model["robot_api_key"]
+        assert model.robot_key == base_model["robot_key"]
         assert model.api_key == base_model["api_key"]
         assert model.use_ssl is True
         assert str(model.endpoint) == INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
@@ -117,13 +117,18 @@ class TestRobotSessionModel:
         with pytest.raises(ValidationError, match=r"Whitespaces are not allowed"):
             RobotSessionModel(**base_model)
 
-    def test_whitespace_validation_robot_api_key(self, base_model):
-        base_model["robot_api_key"] = "abc def"
+    def test_whitespace_validation_robot_key(self, base_model):
+        base_model["robot_key"] = "abc def"
         with pytest.raises(ValidationError, match=r"Whitespaces are not allowed"):
             RobotSessionModel(**base_model)
 
     def test_whitespace_validation_api_key(self, base_model):
         base_model["api_key"] = "abc def"
+        with pytest.raises(ValidationError, match=r"Whitespaces are not allowed"):
+            RobotSessionModel(**base_model)
+
+    def test_whitespace_validation_account_id(self, base_model):
+        base_model["account_id"] = "abc def"
         with pytest.raises(ValidationError, match=r"Whitespaces are not allowed"):
             RobotSessionModel(**base_model)
 
@@ -136,7 +141,7 @@ class TestRobotSessionModel:
         init_input = {
             "robot_id": "123",
             "robot_name": "test_robot",
-            "robot_api_key": "valid_robot_api_key",
+            "robot_key": "valid_robot_key",
         }
         model = RobotSessionModel(**init_input)
         assert model.api_key == "env_valid_key"
@@ -150,7 +155,7 @@ class TestRobotSessionModel:
         init_input = {
             "robot_id": "123",
             "robot_name": "test_robot",
-            "robot_api_key": "valid_robot_api_key",
+            "robot_key": "valid_robot_key",
         }
         model = RobotSessionModel(**init_input)
         assert model.use_ssl is False

--- a/inorbit_edge/tests/test_models.py
+++ b/inorbit_edge/tests/test_models.py
@@ -94,7 +94,7 @@ class TestRobotSessionModel:
         return {
             "robot_id": "123",
             "robot_name": "test_robot",
-            "robot_key": "valid_robot_key",
+            "robot_api_key": "valid_robot_api_key",
             "api_key": "valid_api_key",
         }
 
@@ -102,7 +102,7 @@ class TestRobotSessionModel:
         model = RobotSessionModel(**base_model)
         assert model.robot_id == base_model["robot_id"]
         assert model.robot_name == base_model["robot_name"]
-        assert model.robot_key == base_model["robot_key"]
+        assert model.robot_api_key == base_model["robot_api_key"]
         assert model.api_key == base_model["api_key"]
         assert model.use_ssl is True
         assert str(model.endpoint) == INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
@@ -117,8 +117,8 @@ class TestRobotSessionModel:
         with pytest.raises(ValidationError, match=r"Whitespaces are not allowed"):
             RobotSessionModel(**base_model)
 
-    def test_whitespace_validation_robot_key(self, base_model):
-        base_model["robot_key"] = "abc def"
+    def test_whitespace_validation_robot_api_key(self, base_model):
+        base_model["robot_api_key"] = "abc def"
         with pytest.raises(ValidationError, match=r"Whitespaces are not allowed"):
             RobotSessionModel(**base_model)
 
@@ -141,7 +141,7 @@ class TestRobotSessionModel:
         init_input = {
             "robot_id": "123",
             "robot_name": "test_robot",
-            "robot_key": "valid_robot_key",
+            "robot_api_key": "valid_robot_api_key",
         }
         model = RobotSessionModel(**init_input)
         assert model.api_key == "env_valid_key"
@@ -155,7 +155,7 @@ class TestRobotSessionModel:
         init_input = {
             "robot_id": "123",
             "robot_name": "test_robot",
-            "robot_key": "valid_robot_key",
+            "robot_api_key": "valid_robot_api_key",
         }
         model = RobotSessionModel(**init_input)
         assert model.use_ssl is False

--- a/inorbit_edge/tests/test_robot_session.py
+++ b/inorbit_edge/tests/test_robot_session.py
@@ -130,7 +130,6 @@ def test_apply_footprint(requests_mock):
         footprint=[
             {"x": -0.5, "y": -0.5},
             {"x": 0.3, "y": -0.5},
-            {"x": 0.7, "y": 0.0},
             {"x": 0.3, "y": 0.5},
             {"x": -0.5, "y": 0.5},
         ],
@@ -166,7 +165,6 @@ def test_apply_footprint(requests_mock):
             "footprint": [
                 {"x": -0.5, "y": -0.5},
                 {"x": 0.3, "y": -0.5},
-                {"x": 0.7, "y": 0.0},
                 {"x": 0.3, "y": 0.5},
                 {"x": -0.5, "y": 0.5},
             ],
@@ -175,8 +173,6 @@ def test_apply_footprint(requests_mock):
     }
 
     # HTTP error
-    adapter = requests_mock.post(
-        f"{INORBIT_REST_API_URL}/configuration/apply", status_code=400
-    )
+    requests_mock.post(f"{INORBIT_REST_API_URL}/configuration/apply", status_code=400)
     with pytest.raises(HTTPError):
         robot_session.apply_footprint(footprint)

--- a/inorbit_edge/tests/test_robot_session.py
+++ b/inorbit_edge/tests/test_robot_session.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from inorbit_edge.robot import RobotSession
-from inorbit_edge.robot import INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
+import pytest
+from requests import HTTPError
+
+from inorbit_edge.robot import RobotSession, RobotFootprintSpec
+from inorbit_edge.robot import INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL, INORBIT_REST_API_URL
 from inorbit_edge import get_module_version
 
 
@@ -116,3 +119,64 @@ def test_method_throttling():
     )
     robot_session._publish_throttling["publish_key_values"]["bar"]["last_ts"] = 0
     assert robot_session._should_publish_message(method="publish_key_values", key="bar")
+
+
+def test_apply_footprint(requests_mock):
+    adapter = requests_mock.post(
+        f"{INORBIT_REST_API_URL}/configuration/apply",
+        json={"operationStatus": "SUCCESS"},
+    )
+    footprint = RobotFootprintSpec(
+        footprint=[
+            {"x": -0.5, "y": -0.5},
+            {"x": 0.3, "y": -0.5},
+            {"x": 0.7, "y": 0.0},
+            {"x": 0.3, "y": 0.5},
+            {"x": -0.5, "y": 0.5},
+        ],
+        radius=0.2,
+    )
+
+    # Missing account_id
+    robot_session = RobotSession(
+        robot_id="id_123",
+        robot_name="name_123",
+        api_key="apikey_123",
+    )
+    with pytest.raises(ValueError):
+        robot_session.apply_footprint(footprint)
+
+    # Successful request
+    robot_session = RobotSession(
+        robot_id="id_123",
+        robot_name="name_123",
+        api_key="apikey_123",
+        account_id="account_123",
+    )
+    robot_session.apply_footprint(footprint)
+    assert adapter.called_once
+    assert adapter.last_request.json() == {
+        "apiVersion": "v0.1",
+        "kind": "RobotFootprint",
+        "metadata": {
+            "id": "all",
+            "scope": "robot/account_123/id_123",
+        },
+        "spec": {
+            "footprint": [
+                {"x": -0.5, "y": -0.5},
+                {"x": 0.3, "y": -0.5},
+                {"x": 0.7, "y": 0.0},
+                {"x": 0.3, "y": 0.5},
+                {"x": -0.5, "y": 0.5},
+            ],
+            "radius": 0.2,
+        },
+    }
+
+    # HTTP error
+    adapter = requests_mock.post(
+        f"{INORBIT_REST_API_URL}/configuration/apply", status_code=400
+    )
+    with pytest.raises(HTTPError):
+        robot_session.apply_footprint(footprint)

--- a/qodana.sarif.json
+++ b/qodana.sarif.json
@@ -11,14 +11,6 @@
           "rules": [],
           "taxa": [
             {
-              "id": "EditorConfig",
-              "name": "EditorConfig"
-            },
-            {
-              "id": "Python",
-              "name": "Python"
-            },
-            {
               "id": "JavaScript and TypeScript",
               "name": "JavaScript and TypeScript"
             },
@@ -29,7 +21,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -39,6 +31,14 @@
                   ]
                 }
               ]
+            },
+            {
+              "id": "EditorConfig",
+              "name": "EditorConfig"
+            },
+            {
+              "id": "Python",
+              "name": "Python"
             },
             {
               "id": "PostCSS",
@@ -59,7 +59,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -85,7 +85,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -103,7 +103,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -115,12 +115,12 @@
               ]
             },
             {
-              "id": "Properties files",
-              "name": "Properties files"
-            },
-            {
               "id": "MySQL",
               "name": "MySQL"
+            },
+            {
+              "id": "Properties files",
+              "name": "Properties files"
             },
             {
               "id": "JavaScript and TypeScript/Potentially undesirable code constructs",
@@ -129,7 +129,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -147,7 +147,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -165,7 +165,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -191,7 +191,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -209,7 +209,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -227,7 +227,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -245,7 +245,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -285,7 +285,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -303,7 +303,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -321,7 +321,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -339,7 +339,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -383,7 +383,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -401,7 +401,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -443,7 +443,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -491,7 +491,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -509,7 +509,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -549,7 +549,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -567,7 +567,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -585,7 +585,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -603,7 +603,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -621,7 +621,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -667,7 +667,7 @@
                 {
                   "target": {
                     "id": "Python",
-                    "index": 1,
+                    "index": 3,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -685,7 +685,7 @@
                 {
                   "target": {
                     "id": "JavaScript and TypeScript",
-                    "index": 2,
+                    "index": 0,
                     "toolComponent": {
                       "name": "QDPY"
                     }
@@ -726,3990 +726,6 @@
         },
         "extensions": [
           {
-            "name": "org.editorconfig.editorconfigjetbrains",
-            "version": "241.17568",
-            "rules": [
-              {
-                "id": "EditorConfigCharClassRedundancy",
-                "shortDescription": {
-                  "text": "Unnecessary character class"
-                },
-                "fullDescription": {
-                  "text": "Reports character classes that consist of a single character. Such classes can be simplified to a character, for example '[a]'→'a'.",
-                  "markdown": "Reports character classes that consist of a single character. Such classes can be simplified to a character, for example `[a]`→`a`."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigCharClassRedundancy",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigRootDeclarationUniqueness",
-                "shortDescription": {
-                  "text": "Extra top-level declaration"
-                },
-                "fullDescription": {
-                  "text": "Reports multiple top-level declarations. There can be only one optional “root=true” top-level declaration in the EditorConfig file. Using multiple top-level declarations is not allowed.",
-                  "markdown": "Reports multiple top-level declarations. There can be only one optional \"root=true\" top-level declaration in the EditorConfig file. Using multiple top-level declarations is not allowed."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "error",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigRootDeclarationUniqueness",
-                    "ideaSeverity": "ERROR",
-                    "qodanaSeverity": "Critical"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigNumerousWildcards",
-                "shortDescription": {
-                  "text": "Too many wildcards"
-                },
-                "fullDescription": {
-                  "text": "Reports sections that contain too many wildcards. Using a lot of wildcards may lead to performance issues.",
-                  "markdown": "Reports sections that contain too many wildcards. Using a lot of wildcards may lead to performance issues."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigNumerousWildcards",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigPartialOverride",
-                "shortDescription": {
-                  "text": "Overlapping sections"
-                },
-                "fullDescription": {
-                  "text": "Reports subsets of files specified in the current section that overlap with other subsets in other sections. For example: '[{foo,bar}]' and '[{foo,bas}]' both contain “foo”.",
-                  "markdown": "Reports subsets of files specified in the current section that overlap with other subsets in other sections. For example: `[{foo,bar}]` and `[{foo,bas}]` both contain \"foo\"."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigPartialOverride",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigEmptySection",
-                "shortDescription": {
-                  "text": "Empty section"
-                },
-                "fullDescription": {
-                  "text": "Reports sections that do not contain any EditorConfig properties.",
-                  "markdown": "Reports sections that do not contain any EditorConfig properties."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigEmptySection",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigShadowingOption",
-                "shortDescription": {
-                  "text": "Overriding property"
-                },
-                "fullDescription": {
-                  "text": "Reports properties that override the same properties defined earlier in the file. For example: '[*.java]\nindent_size=4\n[{*.java,*.js}]\nindent_size=2' The second section includes the same files as '[*.java]' but also sets indent_size to value 2. Thus the first declaration 'indent_size=4'will be ignored.",
-                  "markdown": "Reports properties that override the same properties defined earlier in the file.\n\nFor example:\n\n\n    [*.java]\n    indent_size=4\n    [{*.java,*.js}]\n    indent_size=2\n\nThe second section includes the same files as `[*.java]` but also sets indent_size to value 2. Thus the first declaration `indent_size=4`will be ignored."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigShadowingOption",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigListAcceptability",
-                "shortDescription": {
-                  "text": "Unexpected value list"
-                },
-                "fullDescription": {
-                  "text": "Reports lists of values that are used in properties in which lists are not supported. In this case, only a single value can be specified.",
-                  "markdown": "Reports lists of values that are used in properties in which lists are not supported. In this case, only a single value can be specified."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "error",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigListAcceptability",
-                    "ideaSeverity": "ERROR",
-                    "qodanaSeverity": "Critical"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigKeyCorrectness",
-                "shortDescription": {
-                  "text": "Unknown property"
-                },
-                "fullDescription": {
-                  "text": "Reports properties that are not supported by the IDE. Note: some “ij” domain properties may require specific language plugins.",
-                  "markdown": "Reports properties that are not supported by the IDE. Note: some \"ij\" domain properties may require specific language plugins."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigKeyCorrectness",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigPatternEnumerationRedundancy",
-                "shortDescription": {
-                  "text": "Unnecessary braces"
-                },
-                "fullDescription": {
-                  "text": "Reports pattern lists that are either empty '{}' or contain just one pattern, for example '{foo}' in contrast to a list containing multiple patterns, for example '{foo,bar}'. In this case braces are handled as a part of the name. For example, the pattern '*.{a}' will match the file 'my.{a}' but not 'my.a'.",
-                  "markdown": "Reports pattern lists that are either empty `{}` or contain just one pattern, for example `{foo}` in contrast to a list containing multiple patterns, for example `{foo,bar}`. In this case braces are handled as a part of the name. For example, the pattern `*.{a}` will match the file `my.{a}` but not `my.a`."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "error",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigPatternEnumerationRedundancy",
-                    "ideaSeverity": "ERROR",
-                    "qodanaSeverity": "Critical"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigEncoding",
-                "shortDescription": {
-                  "text": "File encoding doesn't match EditorConfig charset"
-                },
-                "fullDescription": {
-                  "text": "Checks that current file encoding matches the encoding defined in \"charset\" property of .editorconfig file.",
-                  "markdown": "Checks that current file encoding matches the encoding defined in \"charset\" property of .editorconfig file."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigEncoding",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigRootDeclarationCorrectness",
-                "shortDescription": {
-                  "text": "Unexpected top-level declaration"
-                },
-                "fullDescription": {
-                  "text": "Reports unexpected top-level declarations. Top-level declarations other than “root=true” are not allowed in the EditorConfig file.",
-                  "markdown": "Reports unexpected top-level declarations. Top-level declarations other than \"root=true\" are not allowed in the EditorConfig file."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "error",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigRootDeclarationCorrectness",
-                    "ideaSeverity": "ERROR",
-                    "qodanaSeverity": "Critical"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigReferenceCorrectness",
-                "shortDescription": {
-                  "text": "Invalid reference"
-                },
-                "fullDescription": {
-                  "text": "Reports identifiers that are either unknown or have a wrong type.",
-                  "markdown": "Reports identifiers that are either unknown or have a wrong type."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "error",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigReferenceCorrectness",
-                    "ideaSeverity": "ERROR",
-                    "qodanaSeverity": "Critical"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigPairAcceptability",
-                "shortDescription": {
-                  "text": "Unexpected key-value pair"
-                },
-                "fullDescription": {
-                  "text": "Reports key-value pairs that are not allowed in the current context.",
-                  "markdown": "Reports key-value pairs that are not allowed in the current context."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "error",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigPairAcceptability",
-                    "ideaSeverity": "ERROR",
-                    "qodanaSeverity": "Critical"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigPatternRedundancy",
-                "shortDescription": {
-                  "text": "Duplicate or redundant pattern"
-                },
-                "fullDescription": {
-                  "text": "Reports file patterns that are redundant as there already are other patterns that define the same scope of files or even a broader one. For example, in '[{*.java,*}]' the first '*.java' pattern defines a narrower scope compared to '*'. That is why it is redundant and can be removed.",
-                  "markdown": "Reports file patterns that are redundant as there already are other patterns that define the same scope of files or even a broader one. For example, in `[{*.java,*}]` the first `*.java` pattern defines a narrower scope compared to `*`. That is why it is redundant and can be removed."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigPatternRedundancy",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigNoMatchingFiles",
-                "shortDescription": {
-                  "text": "No matching files"
-                },
-                "fullDescription": {
-                  "text": "Reports sections with wildcard patterns that do not match any files under the directory in which the '.editorconfig' file is located.",
-                  "markdown": "Reports sections with wildcard patterns that do not match any files under the directory in which the `.editorconfig` file is located."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigNoMatchingFiles",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigDeprecatedDescriptor",
-                "shortDescription": {
-                  "text": "Deprecated property"
-                },
-                "fullDescription": {
-                  "text": "Reports EditorConfig properties that are no longer supported.",
-                  "markdown": "Reports EditorConfig properties that are no longer supported."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigDeprecatedDescriptor",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigWildcardRedundancy",
-                "shortDescription": {
-                  "text": "Redundant wildcard"
-                },
-                "fullDescription": {
-                  "text": "Reports wildcards that become redundant when the “**” wildcard is used in the same section. The “**” wildcard defines a broader set of files than any other wildcard. That is why, any other wildcard used in the same section has no affect and can be removed.",
-                  "markdown": "Reports wildcards that become redundant when the \"\\*\\*\" wildcard is used in the same section.\n\n\nThe \"\\*\\*\" wildcard defines a broader set of files than any other wildcard.\nThat is why, any other wildcard used in the same section has no affect and can be removed."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigWildcardRedundancy",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigHeaderUniqueness",
-                "shortDescription": {
-                  "text": "EditorConfig section is not unique"
-                },
-                "fullDescription": {
-                  "text": "Reports sections that define the same file pattern as other sections.",
-                  "markdown": "Reports sections that define the same file pattern as other sections."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigHeaderUniqueness",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigShadowedOption",
-                "shortDescription": {
-                  "text": "Overridden property"
-                },
-                "fullDescription": {
-                  "text": "Reports properties that are already defined in other sections. For example: '[*.java]\nindent_size=4\n[{*.java,*.js}]\nindent_size=2' The second section includes all '*.java' files too but it also redefines indent_size. As a result the value 2 will be used for files matching '*.java'.",
-                  "markdown": "Reports properties that are already defined in other sections.\n\nFor example:\n\n\n    [*.java]\n    indent_size=4\n    [{*.java,*.js}]\n    indent_size=2\n\nThe second section includes all `*.java` files too but it also redefines indent_size. As a result the value 2 will be used for files matching `*.java`."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigShadowedOption",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigEmptyHeader",
-                "shortDescription": {
-                  "text": "Empty header"
-                },
-                "fullDescription": {
-                  "text": "Reports sections with an empty header. Section header must contain file path globs in the format similar to one supported by 'gitignore'.",
-                  "markdown": "Reports sections with an empty header. Section header must contain file path globs in the format similar to one supported by `gitignore`."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "error",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigEmptyHeader",
-                    "ideaSeverity": "ERROR",
-                    "qodanaSeverity": "Critical"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigValueCorrectness",
-                "shortDescription": {
-                  "text": "Invalid property value"
-                },
-                "fullDescription": {
-                  "text": "Reports property values that do not meet value restrictions. For example, some properties may be only “true” or “false”, others contain only integer numbers etc. If a value has a limited set of variants, use code completion to see all of them.",
-                  "markdown": "Reports property values that do not meet value restrictions. For example, some properties may be only \"true\" or \"false\", others contain only integer numbers etc. If a value has a limited set of variants, use code completion to see all of them."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "error",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigValueCorrectness",
-                    "ideaSeverity": "ERROR",
-                    "qodanaSeverity": "Critical"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigVerifyByCore",
-                "shortDescription": {
-                  "text": "Invalid .editorconfig file"
-                },
-                "fullDescription": {
-                  "text": "Verifies the whole file using the backing EditorConfig core library and reports any failures. Any such failure would prevent EditorConfig properties from being correctly applied.",
-                  "markdown": "Verifies the whole file using the backing EditorConfig core library and reports any failures. Any such failure would prevent EditorConfig properties from being correctly applied."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "error",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigVerifyByCore",
-                    "ideaSeverity": "ERROR",
-                    "qodanaSeverity": "Critical"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigValueUniqueness",
-                "shortDescription": {
-                  "text": "Non-unique list value"
-                },
-                "fullDescription": {
-                  "text": "Reports duplicates in lists of values.",
-                  "markdown": "Reports duplicates in lists of values."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "error",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigValueUniqueness",
-                    "ideaSeverity": "ERROR",
-                    "qodanaSeverity": "Critical"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigMissingRequiredDeclaration",
-                "shortDescription": {
-                  "text": "Required declarations are missing"
-                },
-                "fullDescription": {
-                  "text": "Reports properties that miss the required declarations. Refer to the documentation for more information.",
-                  "markdown": "Reports properties that miss the required declarations. Refer to the documentation for more information."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "error",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigMissingRequiredDeclaration",
-                    "ideaSeverity": "ERROR",
-                    "qodanaSeverity": "Critical"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigCharClassLetterRedundancy",
-                "shortDescription": {
-                  "text": "Duplicate character class letter"
-                },
-                "fullDescription": {
-                  "text": "Reports wildcard patterns in the EditorConfig section that contain a duplicate character in the character class, for example '[aa]'.",
-                  "markdown": "Reports wildcard patterns in the EditorConfig section that contain a duplicate character in the character class, for example `[aa]`."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigCharClassLetterRedundancy",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigSpaceInHeader",
-                "shortDescription": {
-                  "text": "Space in file pattern"
-                },
-                "fullDescription": {
-                  "text": "Reports space characters in wildcard patterns that affect pattern matching. If these characters are not intentional, they should be removed.",
-                  "markdown": "Reports space characters in wildcard patterns that affect pattern matching. If these characters are not intentional, they should be removed."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigSpaceInHeader",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigOptionRedundancy",
-                "shortDescription": {
-                  "text": "Redundant property"
-                },
-                "fullDescription": {
-                  "text": "Reports properties that are redundant when another applicable section already contains the same property and value. For example: '[*]\nindent_size=4\n[*.java]\nindent_size=4' are both applicable to '*.java' files and define the same 'indent_size' value.",
-                  "markdown": "Reports properties that are redundant when another applicable section already contains the same property and value.\n\n\nFor example:\n\n\n    [*]\n    indent_size=4\n    [*.java]\n    indent_size=4\n\nare both applicable to `*.java` files and define the same `indent_size` value."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigOptionRedundancy",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigUnusedDeclaration",
-                "shortDescription": {
-                  "text": "Unused declaration"
-                },
-                "fullDescription": {
-                  "text": "Reports unused declarations. Such declarations can be removed.",
-                  "markdown": "Reports unused declarations. Such declarations can be removed."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigUnusedDeclaration",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "EditorConfigUnexpectedComma",
-                "shortDescription": {
-                  "text": "Unexpected comma"
-                },
-                "fullDescription": {
-                  "text": "Reports commas that cannot be used in the current context. Commas are allowed only as separators for values in lists.",
-                  "markdown": "Reports commas that cannot be used in the current context. Commas are allowed only as separators for values in lists."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "error",
-                  "parameters": {
-                    "suppressToolId": "EditorConfigUnexpectedComma",
-                    "ideaSeverity": "ERROR",
-                    "qodanaSeverity": "Critical"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "EditorConfig",
-                      "index": 0,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "language": "en-US",
-            "contents": [
-              "localizedData",
-              "nonLocalizedData"
-            ],
-            "isComprehensive": false
-          },
-          {
-            "name": "Pythonid",
-            "version": "241.17568",
-            "rules": [
-              {
-                "id": "PyPandasSeriesToListInspection",
-                "shortDescription": {
-                  "text": "Method Series.to_list() is recommended"
-                },
-                "fullDescription": {
-                  "text": "Reports redundant 'list' in 'list(Series.values)' statement for pandas and polars libraries. Such 'Series' values extraction can be replaced with the 'to_list()' function call. Example: list(df['column'].values)\n When the quick-fix is applied, the code changes to: df['column'].to_list()",
-                  "markdown": "Reports redundant `list` in `list(Series.values)` statement for pandas and polars libraries.\nSuch `Series` values extraction can be replaced with the `to_list()` function call.\n\n**Example:**\n\n```\nlist(df['column'].values)\n```\n\nWhen the quick-fix is applied, the code changes to:\n\n```\ndf['column'].to_list()\n```"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyPackages",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PySetFunctionToLiteralInspection",
-                "shortDescription": {
-                  "text": "Function call can be replaced with set literal"
-                },
-                "fullDescription": {
-                  "text": "Reports calls to the 'set' function that can be replaced with the 'set' literal. Example: 'def do_mult(a, b):\n    c = a * b\n    return set([c, a, b])' When the quick-fix is applied, the code changes to: 'def do_mult(a, b):\n    c = a * b\n    return {c, a, b}'",
-                  "markdown": "Reports calls to the `set` function that can be replaced with\nthe `set` literal.\n\n**Example:**\n\n\n    def do_mult(a, b):\n        c = a * b\n        return set([c, a, b])\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    def do_mult(a, b):\n        c = a * b\n        return {c, a, b}\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PySetFunctionToLiteral",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyOverridesInspection",
-                "shortDescription": {
-                  "text": "Invalid usages of @override decorator"
-                },
-                "fullDescription": {
-                  "text": "Reports when a method decorated with @override doesn't have a matching method in its ancestor classes Example: 'from typing import override\n\nclass Parent:\n    def foo(self) -> int:\n        return 1\n\n    def bar(self, x: str) -> str:\n        return x\n\nclass Child(Parent):\n    @override\n    def foo(self) -> int:\n        return 2\n\n    @override # Missing super method for override function\n    def baz(self) -> int:\n        return 1'",
-                  "markdown": "Reports when a method decorated with @override doesn't have a matching method in its ancestor classes\n\n**Example:**\n\n\n    from typing import override\n\n    class Parent:\n        def foo(self) -> int:\n            return 1\n\n        def bar(self, x: str) -> str:\n            return x\n\n    class Child(Parent):\n        @override\n        def foo(self) -> int:\n            return 2\n\n        @override # Missing super method for override function\n        def baz(self) -> int:\n            return 1\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyOverrides",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyInitNewSignatureInspection",
-                "shortDescription": {
-                  "text": "Incompatible signatures of __new__ and __init__"
-                },
-                "fullDescription": {
-                  "text": "Reports incompatible signatures of the '__new__' and '__init__' methods. Example: 'class MyClass(object):\n    def __new__(cls, arg1):\n        return super().__new__(cls)\n\n    def __init__(self):\n        pass' If the '__new__' and '__init__' have different arguments, then the 'MyClass' cannot be instantiated. As a fix, the IDE offers to apply the Change Signature refactoring.",
-                  "markdown": "Reports incompatible signatures of the `__new__` and `__init__` methods.\n\n**Example:**\n\n\n    class MyClass(object):\n        def __new__(cls, arg1):\n            return super().__new__(cls)\n\n        def __init__(self):\n            pass\n\nIf the `__new__` and `__init__` have different arguments, then the `MyClass`\ncannot be instantiated.\n\nAs a fix, the IDE offers to apply the Change Signature refactoring."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyInitNewSignature",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyMissingConstructorInspection",
-                "shortDescription": {
-                  "text": "Missed call to '__init__' of the super class"
-                },
-                "fullDescription": {
-                  "text": "Reports cases when a call to the 'super' constructor in a class is missed. Example: 'class Fruit:\n    def __init__(self):\n        pass\n\n\nclass Pear(Fruit):\n    def __init__(self):\n        pass' The 'Pear' class should have a 'super' call in the '__init__' method. When the quick-fix is applied, the code changes to: 'class Fruit:\n    def __init__(self):\n        pass\n\n\nclass Pear(Fruit):\n    def __init__(self):\n        super().__init__()'",
-                  "markdown": "Reports cases when a call to the `super` constructor in a class is missed.\n\n**Example:**\n\n\n    class Fruit:\n        def __init__(self):\n            pass\n\n\n    class Pear(Fruit):\n        def __init__(self):\n            pass\n\nThe `Pear` class should have a `super` call in the `__init__`\nmethod.\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    class Fruit:\n        def __init__(self):\n            pass\n\n\n    class Pear(Fruit):\n        def __init__(self):\n            super().__init__()\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyMissingConstructor",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PySimplifyBooleanCheckInspection",
-                "shortDescription": {
-                  "text": "Redundant boolean variable check"
-                },
-                "fullDescription": {
-                  "text": "Reports equality comparison with a boolean literal. Example: 'def func(s):\n    if s.isdigit() == True:\n        return int(s)' With the quick-fix applied, the code fragment will be simplified to: 'def func(s):\n    if s.isdigit():\n        return int(s)'",
-                  "markdown": "Reports equality comparison with a boolean literal.\n\n**Example:**\n\n\n    def func(s):\n        if s.isdigit() == True:\n            return int(s)\n\nWith the quick-fix applied, the code fragment will be simplified to:\n\n\n    def func(s):\n        if s.isdigit():\n            return int(s)\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PySimplifyBooleanCheck",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyCallingNonCallableInspection",
-                "shortDescription": {
-                  "text": "Attempt to call a non-callable object"
-                },
-                "fullDescription": {
-                  "text": "Reports a problem when you are trying to call objects that are not callable, like, for example, properties: Example: 'class Record:\n    @property\n    def as_json(self):\n\njson = Record().as_json()'",
-                  "markdown": "Reports a problem when you are trying\nto call objects that are not callable, like, for example, properties:\n\n**Example:**\n\n\n    class Record:\n        @property\n        def as_json(self):\n\n    json = Record().as_json()\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyCallingNonCallable",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyUnreachableCodeInspection",
-                "shortDescription": {
-                  "text": "Unreachable code"
-                },
-                "fullDescription": {
-                  "text": "Reports code fragments that cannot be normally reached. Example: 'if True:\n    print('Yes')\nelse:\n    print('No')' As a fix, you might want to check and modify the algorithm to ensure it implements the expected logic.",
-                  "markdown": "Reports code fragments that cannot be normally reached.\n\n**Example:**\n\n\n    if True:\n        print('Yes')\n    else:\n        print('No')\n\nAs a fix, you might want to check and modify the algorithm to ensure it implements\nthe expected logic."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyUnreachableCode",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyChainedComparisonsInspection",
-                "shortDescription": {
-                  "text": "Too complex chained comparisons"
-                },
-                "fullDescription": {
-                  "text": "Reports chained comparisons that can be simplified. Example: 'def do_comparison(x):\n      xmin = 10\n      xmax = 100\n      if x >= xmin and x <= xmax:\n          pass' The IDE offers to simplify 'if x >= xmin and x <= xmax'. When the quick-fix is applied, the code changes to: 'def do_comparison(x):\n      xmin = 10\n      xmax = 100\n      if xmin <= x <= xmax:\n          pass'",
-                  "markdown": "Reports chained comparisons that can be simplified.\n\n**Example:**\n\n\n      def do_comparison(x):\n          xmin = 10\n          xmax = 100\n          if x >= xmin and x <= xmax:\n              pass\n\nThe IDE offers to simplify `if x >= xmin and x <= xmax`.\nWhen the quick-fix is applied, the code changes to:\n\n\n      def do_comparison(x):\n          xmin = 10\n          xmax = 100\n          if xmin <= x <= xmax:\n              pass\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyChainedComparisons",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyCompatibilityInspection",
-                "shortDescription": {
-                  "text": "Code is incompatible with specific Python versions"
-                },
-                "fullDescription": {
-                  "text": "Reports incompatibility with the specified versions of Python. Enable this inspection if you need your code to be compatible with a range of Python versions, for example, if you are building a library. To define the range of the inspected Python versions, select the corresponding checkboxes in the Options section. For more information about the Python versions supported by the IDE, see the web help.",
-                  "markdown": "Reports incompatibility with the specified versions of Python.\nEnable this inspection if you need your code to be compatible with a range of Python versions, for example,\nif you are building a library.\n\nTo define the range of the inspected Python versions, select the corresponding checkboxes in the **Options**\nsection.\n\nFor more information about the Python versions supported by the IDE, see the\n[web help](https://www.jetbrains.com/help/pycharm/python.html#support)."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyCompatibility",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyGlobalUndefinedInspection",
-                "shortDescription": {
-                  "text": "Global variable is not defined at the module level"
-                },
-                "fullDescription": {
-                  "text": "Reports problems when a variable defined through the 'global' statement is not defined in the module scope. Example: 'def foo():\n    global bar\n    print(bar)\n\nfoo()' As a fix, you can move the global variable declaration: 'global bar\n\n\ndef foo():\n    print(bar)'",
-                  "markdown": "Reports problems when a variable defined through the `global`\nstatement is not defined in the module scope.\n\n**Example:**\n\n\n    def foo():\n        global bar\n        print(bar)\n\n    foo()\n\nAs a fix, you can move the global variable declaration:\n\n\n    global bar\n\n\n    def foo():\n        print(bar)\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyGlobalUndefined",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "UnsatisfiedRequirementInspection",
-                "shortDescription": {
-                  "text": "Requirement is not satisfied"
-                },
-                "fullDescription": {
-                  "text": "Reports packages mentioned in requirements files (for example, 'requirements.txt', or 'dependencies' section in 'pyproject.toml' files) but not installed, or imported but not mentioned in requirements files.",
-                  "markdown": "Reports packages mentioned in requirements files (for example, `requirements.txt`, or `dependencies` section in `pyproject.toml` files) but not installed,\nor imported but not mentioned in requirements files."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "UnsatisfiedRequirement",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Requirements",
-                      "index": 37,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyProtocolInspection",
-                "shortDescription": {
-                  "text": "Invalid protocol definitions and usages"
-                },
-                "fullDescription": {
-                  "text": "Reports invalid definitions and usages of protocols introduced in PEP-544. Example: 'from typing import Protocol\n\n\nclass MyProtocol(Protocol):\n    def method(self, p: int) -> str:\n        pass\n\n\nclass MyClass(MyProtocol):\n    def method(self, p: str) -> int: # Type of 'method' is not compatible with 'MyProtocol'\n        pass\n\n\nclass MyAnotherProtocol(MyClass, Protocol): # All bases of a protocol must be protocols\n    pass'",
-                  "markdown": "Reports invalid definitions and usages of protocols introduced in\n[PEP-544](https://www.python.org/dev/peps/pep-0544/).\n\n**Example:**\n\n\n    from typing import Protocol\n\n\n    class MyProtocol(Protocol):\n        def method(self, p: int) -> str:\n            pass\n\n\n    class MyClass(MyProtocol):\n        def method(self, p: str) -> int: # Type of 'method' is not compatible with 'MyProtocol'\n            pass\n\n\n    class MyAnotherProtocol(MyClass, Protocol): # All bases of a protocol must be protocols\n        pass\n\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyProtocol",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyTypeHintsInspection",
-                "shortDescription": {
-                  "text": "Invalid type hints definitions and usages"
-                },
-                "fullDescription": {
-                  "text": "Reports invalid usages of type hints. Example: 'from typing import TypeVar\n\nT0 = TypeVar('T1') # Argument of 'TypeVar' must be 'T0'\n\n\ndef b(p: int) -> int:  # Type specified both in a comment and annotation\n    # type: (int) -> int\n    pass\n\n\ndef c(p1, p2): # Type signature has too many arguments\n    # type: (int) -> int\n    pass' Available quick-fixes offer various actions. You can rename, remove, or move problematic elements. You can also manually modify type declarations to ensure no warning is shown.",
-                  "markdown": "Reports invalid usages of type hints.\n\n**Example:**\n\n\n    from typing import TypeVar\n\n    T0 = TypeVar('T1') # Argument of 'TypeVar' must be 'T0'\n\n\n    def b(p: int) -> int:  # Type specified both in a comment and annotation\n        # type: (int) -> int\n        pass\n\n\n    def c(p1, p2): # Type signature has too many arguments\n        # type: (int) -> int\n        pass\n\nAvailable quick-fixes offer various actions. You can rename, remove, or move problematic elements. You can also manually modify type declarations to ensure no warning is shown."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyTypeHints",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyMethodMayBeStaticInspection",
-                "shortDescription": {
-                  "text": "Method is not declared static"
-                },
-                "fullDescription": {
-                  "text": "Reports any methods that do not require a class instance creation and can be made static. Example: 'class MyClass(object):\n    def my_method(self, x):\n        print(x)' If a Make function from method quick-fix is applied, the code changes to: 'def my_method(x):\n    print(x)\n\n\nclass MyClass(object):\n    pass' If you select the Make method static quick-fix, the '@staticmethod' decorator is added: 'class MyClass(object):\n    @staticmethod\n    def my_method(x):\n        print(x)'",
-                  "markdown": "Reports any methods that do not require a class instance creation and can be\nmade static.\n\n**Example:**\n\n\n    class MyClass(object):\n        def my_method(self, x):\n            print(x)\n\nIf a **Make function from method** quick-fix is applied, the code changes to:\n\n\n    def my_method(x):\n        print(x)\n\n\n    class MyClass(object):\n        pass\n\nIf you select the **Make method static** quick-fix, the `@staticmethod` decorator is added:\n\n\n    class MyClass(object):\n        @staticmethod\n        def my_method(x):\n            print(x)\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyMethodMayBeStatic",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "CythonUsageBeforeDeclarationInspection",
-                "shortDescription": {
-                  "text": "Cython variable is used before its declaration"
-                },
-                "fullDescription": {
-                  "text": "Reports Cython variables being referenced before declaration. Example: 'cdef int c_x\n\nprint(c_x, c_y)  # Variable 'c_y' is used before its declaration\n\ncdef int c_y = 0'",
-                  "markdown": "Reports Cython variables being referenced before declaration.\n\n**Example:**\n\n\n    cdef int c_x\n\n    print(c_x, c_y)  # Variable 'c_y' is used before its declaration\n\n    cdef int c_y = 0\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "CythonUsageBeforeDeclaration",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyDictCreationInspection",
-                "shortDescription": {
-                  "text": "Dictionary creation can be rewritten by dictionary literal"
-                },
-                "fullDescription": {
-                  "text": "Reports situations when you can rewrite dictionary creation by using a dictionary literal. This approach brings performance improvements. Example: 'dic = {}\ndic['var'] = 1' When the quick-fix is applied, the code changes to: 'dic = {'var': 1}'",
-                  "markdown": "Reports situations when you can rewrite dictionary creation\nby using a dictionary literal.\n\nThis approach brings performance improvements.\n\n**Example:**\n\n\n    dic = {}\n    dic['var'] = 1\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    dic = {'var': 1}\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyDictCreation",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyStringFormatInspection",
-                "shortDescription": {
-                  "text": "Errors in string formatting operations"
-                },
-                "fullDescription": {
-                  "text": "Reports errors in string formatting operations. Example 1: '\"Hello {1}\".format(\"people\")' Example 2: 'def bar():\n    return 1\n\n\n\"%s %s\" % bar()' As a fix, you need to rewrite string formatting fragments to adhere to the formatting syntax.",
-                  "markdown": "Reports errors in string formatting operations.\n\n**Example 1:**\n\n\n    \"Hello {1}\".format(\"people\")\n\n**Example 2:**\n\n\n    def bar():\n        return 1\n\n\n    \"%s %s\" % bar()\n\nAs a fix, you need to rewrite string formatting fragments to\nadhere to the [formatting syntax](https://docs.python.org/3/library/string.html#format-string-syntax)."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyStringFormat",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyExceptionInheritInspection",
-                "shortDescription": {
-                  "text": "Exceptions do not inherit from standard 'Exception' class"
-                },
-                "fullDescription": {
-                  "text": "Reports cases when a custom exception class is raised but does not inherit from the builtin Exception class. Example: 'class A:\n    pass\n\n\ndef me_exception():\n    raise A()' The proposed quick-fix changes the code to: 'class A(Exception):\n    pass\n\n\ndef me_exception():\n    raise A()'",
-                  "markdown": "Reports cases when a custom exception class is\nraised but does not inherit from the\n[builtin Exception class](https://docs.python.org/3/library/exceptions.html).\n\n**Example:**\n\n\n    class A:\n        pass\n\n\n    def me_exception():\n        raise A()\n\nThe proposed quick-fix changes the code to:\n\n\n    class A(Exception):\n        pass\n\n\n    def me_exception():\n        raise A()\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyExceptionInherit",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyAssignmentToLoopOrWithParameterInspection",
-                "shortDescription": {
-                  "text": "Assignments to 'for' loop or 'with' statement parameter"
-                },
-                "fullDescription": {
-                  "text": "Reports the cases when you rewrite a loop variable with an inner loop. Example: 'for i in range(5):\n      for i in range(20, 25):\n          print(\"Inner\", i)\n      print(\"Outer\", i)' It also warns you if a variable declared in the 'with' statement is redeclared inside the statement body: 'with open(\"file\") as f:\n      f.read()\n      with open(\"file\") as f:'",
-                  "markdown": "Reports the cases when you rewrite a loop variable with an inner loop.\n\n**Example:**\n\n\n        for i in range(5):\n          for i in range(20, 25):\n              print(\"Inner\", i)\n          print(\"Outer\", i)\n      \nIt also warns you if a variable declared in the `with` statement is redeclared inside the statement body:\n\n\n        with open(\"file\") as f:\n          f.read()\n          with open(\"file\") as f:\n      \n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyAssignmentToLoopOrWithParameter",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PySuperArgumentsInspection",
-                "shortDescription": {
-                  "text": "Wrong arguments to call super"
-                },
-                "fullDescription": {
-                  "text": "Reports cases when any call to 'super(A, B)' does not meet the following requirements: 'B' is an instance of 'A' 'B' a subclass of 'A' Example: 'class Figure:\n    def color(self):\n        pass\n\n\nclass Rectangle(Figure):\n    def color(self):\n        pass\n\n\nclass Square(Figure):\n    def color(self):\n        return super(Rectangle, self).color() # Square is not an instance or subclass of Rectangle' As a fix, you can make the 'Square' an instance of the 'Rectangle' class.",
-                  "markdown": "Reports cases when any call to `super(A, B)` does not meet the\nfollowing requirements:\n\n* `B` is an instance of `A`\n* `B` a subclass of `A`\n\n**Example:**\n\n\n    class Figure:\n        def color(self):\n            pass\n\n\n    class Rectangle(Figure):\n        def color(self):\n            pass\n\n\n    class Square(Figure):\n        def color(self):\n            return super(Rectangle, self).color() # Square is not an instance or subclass of Rectangle\n\nAs a fix, you can make the `Square` an instance of the `Rectangle` class."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PySuperArguments",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyNonAsciiCharInspection",
-                "shortDescription": {
-                  "text": "File contains non-ASCII character"
-                },
-                "fullDescription": {
-                  "text": "Reports cases in Python 2 when a file contains non-ASCII characters and does not have an encoding declaration at the top. Example: 'class A(object):\n# №5\n    def __init__(self):\n        pass' In this example, the IDE reports a non-ASCII symbol in a comment and a lack of encoding declaration. Apply the proposed quick-fix to add a missing encoding declaration: '# coding=utf-8\nclass A(object)\n# №5\n    def __init__(self):\n        pass'",
-                  "markdown": "Reports cases in Python 2 when a file contains non-ASCII characters and does not\nhave an encoding declaration at the top.\n\n**Example:**\n\n\n    class A(object):\n    # №5\n        def __init__(self):\n            pass\n\nIn this example, the IDE reports a non-ASCII symbol in a comment and a lack of encoding\ndeclaration. Apply the proposed quick-fix to add a missing encoding declaration:\n\n\n    # coding=utf-8\n    class A(object)\n    # №5\n        def __init__(self):\n            pass\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyNonAsciiChar",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyAbstractClassInspection",
-                "shortDescription": {
-                  "text": "Class must implement all abstract methods"
-                },
-                "fullDescription": {
-                  "text": "Reports cases when not all abstract properties or methods are defined in a subclass. Example: 'from abc import abstractmethod, ABC\n\n\nclass Figure(ABC):\n\n    @abstractmethod\n    def do_figure(self):\n        pass\n\n\nclass Triangle(Figure):\n    def do_triangle(self):\n        pass' When the quick-fix is applied, the IDE implements an abstract method for the 'Triangle' class: 'from abc import abstractmethod, ABC\n\n\nclass Figure(ABC):\n\n    @abstractmethod\n    def do_figure(self):\n        pass\n\n\nclass Triangle(Figure):\n    def do_figure(self):\n        pass\n\n    def do_triangle(self):\n        pass'",
-                  "markdown": "Reports cases when not all abstract properties or methods are defined in\na subclass.\n\n**Example:**\n\n\n    from abc import abstractmethod, ABC\n\n\n    class Figure(ABC):\n\n        @abstractmethod\n        def do_figure(self):\n            pass\n\n\n    class Triangle(Figure):\n        def do_triangle(self):\n            pass\n\nWhen the quick-fix is applied, the IDE implements an abstract method for the `Triangle` class:\n\n\n    from abc import abstractmethod, ABC\n\n\n    class Figure(ABC):\n\n        @abstractmethod\n        def do_figure(self):\n            pass\n\n\n    class Triangle(Figure):\n        def do_figure(self):\n            pass\n\n        def do_triangle(self):\n            pass\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyAbstractClass",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyOldStyleClassesInspection",
-                "shortDescription": {
-                  "text": "Old-style class contains new-style class features"
-                },
-                "fullDescription": {
-                  "text": "Reports occurrences of new-style class features in old-style classes. The inspection highlights '__slots__', '__getattribute__', and 'super()' inside old-style classes.",
-                  "markdown": "Reports occurrences of\n[new-style class features](https://www.python.org/doc/newstyle/)\nin old-style classes. The inspection highlights\n`__slots__`, `__getattribute__`, and `super()`\ninside old-style classes."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyOldStyleClasses",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyBroadExceptionInspection",
-                "shortDescription": {
-                  "text": "Unclear exception clauses"
-                },
-                "fullDescription": {
-                  "text": "Reports exception clauses that do not provide specific information about the problem. Example: Clauses that do not specify an exception class Clauses that are specified as 'Exception'",
-                  "markdown": "Reports exception clauses that do not provide specific information\nabout the problem.\n\n**Example:**\n\n* Clauses that do not specify an exception class\n* Clauses that are specified as `Exception`"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyBroadException",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyTypeCheckerInspection",
-                "shortDescription": {
-                  "text": "Incorrect type"
-                },
-                "fullDescription": {
-                  "text": "Reports type errors in function call expressions, targets, and return values. In a dynamically typed language, this is possible in a limited number of cases. Types of function parameters can be specified in docstrings or in Python 3 function annotations. Example: 'def foo() -> int:\n    return \"abc\" # Expected int, got str\n\n\na: str\na = foo() # Expected str, got int' With the quick-fix, you can modify the problematic types: 'def foo() -> str:\n    return \"abc\"\n\n\na: str\na = foo()'",
-                  "markdown": "Reports type errors in function call expressions, targets, and return values. In a dynamically typed language, this is possible in a limited number of cases.\n\nTypes of function parameters can be specified in\ndocstrings or in Python 3 function annotations.\n\n**Example:**\n\n\n    def foo() -> int:\n        return \"abc\" # Expected int, got str\n\n\n    a: str\n    a = foo() # Expected str, got int\n\nWith the quick-fix, you can modify the problematic types:\n\n\n    def foo() -> str:\n        return \"abc\"\n\n\n    a: str\n    a = foo()\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyTypeChecker",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyByteLiteralInspection",
-                "shortDescription": {
-                  "text": "A byte literal contains a non-ASCII character"
-                },
-                "fullDescription": {
-                  "text": "Reports characters in byte literals that are outside ASCII range. Example: 's = b'№5''",
-                  "markdown": "Reports characters in byte literals that are outside ASCII range.\n\n**Example:**\n\n\n      s = b'№5'\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyByteLiteral",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyAugmentAssignmentInspection",
-                "shortDescription": {
-                  "text": "Assignment can be replaced with augmented assignment"
-                },
-                "fullDescription": {
-                  "text": "Reports assignments that can be replaced with augmented assignments. Example: 'a = 23\nb = 3\na = a + b' After the quick-fix is applied, the code changes to: 'a = 23\nb = 3\na += b'",
-                  "markdown": "Reports assignments that can be replaced with augmented assignments.\n\n**Example:**\n\n\n    a = 23\n    b = 3\n    a = a + b\n\nAfter the quick-fix is applied, the code changes to:\n\n\n    a = 23\n    b = 3\n    a += b\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyAugmentAssignment",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyDeprecationInspection",
-                "shortDescription": {
-                  "text": "Deprecated function, class, or module"
-                },
-                "fullDescription": {
-                  "text": "Reports usages of Python functions, or methods that are marked as deprecated and raise the 'DeprecationWarning' or 'PendingDeprecationWarning' warning. Also, this inspection highlights usages of 'abc.abstractstaticmethod', 'abc.abstractproperty', and 'abc.abstractclassmethod' decorators. Example: 'class Foo:\n    @property\n    def bar(self):\n        import warnings\n        warnings.warn(\"this is deprecated\", DeprecationWarning, 2)\n        return 5\n\n\nfoo = Foo()\nprint(foo.bar)'",
-                  "markdown": "Reports usages of Python functions, or methods that are marked as\ndeprecated and raise the `DeprecationWarning` or `PendingDeprecationWarning` warning.\n\nAlso, this inspection highlights usages of `abc.abstractstaticmethod`, `abc.abstractproperty`, and `abc.abstractclassmethod`\ndecorators.\n\n**Example:**\n\n\n    class Foo:\n        @property\n        def bar(self):\n            import warnings\n            warnings.warn(\"this is deprecated\", DeprecationWarning, 2)\n            return 5\n\n\n    foo = Foo()\n    print(foo.bar)\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyDeprecation",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyUnnecessaryBackslashInspection",
-                "shortDescription": {
-                  "text": "Unnecessary backslash"
-                },
-                "fullDescription": {
-                  "text": "Reports backslashes in places where line continuation is implicit inside '()', '[]', and '{}'. Example: 'a = ('first', \\\n     'second', 'third')' When the quick-fix is applied, the redundant backslash is deleted.",
-                  "markdown": "Reports backslashes in places where line continuation is implicit inside `()`,\n`[]`, and `{}`.\n\n**Example:**\n\n\n    a = ('first', \\\n         'second', 'third')\n\nWhen the quick-fix is applied, the redundant backslash is deleted."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyUnnecessaryBackslash",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyShadowingNamesInspection",
-                "shortDescription": {
-                  "text": "Shadowing names from outer scopes"
-                },
-                "fullDescription": {
-                  "text": "Reports shadowing names defined in outer scopes. Example: 'def outer(p):\n    def inner(p):\n        pass' As a quick-fix, the IDE offers to remove a parameter or rename it.",
-                  "markdown": "Reports shadowing names defined in outer scopes.\n\n**Example:**\n\n\n    def outer(p):\n        def inner(p):\n            pass\n\nAs a quick-fix, the IDE offers to remove a parameter or rename it."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyShadowingNames",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyFinalInspection",
-                "shortDescription": {
-                  "text": "Invalid usages of final classes, methods, and variables"
-                },
-                "fullDescription": {
-                  "text": "Reports invalid usages of final classes, methods and variables. Example: 'from typing import final\n\n\n@final\nclass A:\n    def a_method(self):\n        pass\n\n\nclass B(A):\n    def a_method(self):\n        pass'",
-                  "markdown": "Reports invalid usages of final classes,\nmethods and variables.\n\n**Example:**\n\n\n    from typing import final\n\n\n    @final\n    class A:\n        def a_method(self):\n            pass\n\n\n    class B(A):\n        def a_method(self):\n            pass\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyFinal",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PySingleQuotedDocstringInspection",
-                "shortDescription": {
-                  "text": "Single quoted docstring"
-                },
-                "fullDescription": {
-                  "text": "Reports docstrings that do not adhere to the triple double-quoted string format. Example: 'def calc(self, balance=0):\n    'param: balance'\n    self.balance = balance' When the quick-fix is applied, the code changes to: 'def calc(self, balance=0):\n    \"\"\"param: balance\"\"\"\n    self.balance = balance'",
-                  "markdown": "Reports docstrings that do not adhere to the triple double-quoted string format.\n\n**Example:**\n\n\n    def calc(self, balance=0):\n        'param: balance'\n        self.balance = balance\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    def calc(self, balance=0):\n        \"\"\"param: balance\"\"\"\n        self.balance = balance\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PySingleQuotedDocstring",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyUnusedLocalInspection",
-                "shortDescription": {
-                  "text": "Unused local symbols"
-                },
-                "fullDescription": {
-                  "text": "Reports local variables, parameters, and functions that are locally defined, but not used name in a function.",
-                  "markdown": "Reports local variables, parameters, and functions that are locally defined, but not used name in a function."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyUnusedLocal",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyReturnFromInitInspection",
-                "shortDescription": {
-                  "text": "__init__ method that returns a value"
-                },
-                "fullDescription": {
-                  "text": "Reports occurrences of 'return' statements with a return value inside '__init__' methods of classes. Example: 'class Sum:\n    def __init__(self, a, b):\n        self.a = a\n        self.b = b\n        self.sum = a + b\n        return self.sum' A constructor should not return any value. The '__init__' method should only initialize the values of instance members for news objects. As a quick-fix, the IDE offers to remove the 'return' statement.",
-                  "markdown": "Reports occurrences of `return` statements with a return value inside\n`__init__` methods of classes.\n\n**Example:**\n\n\n    class Sum:\n        def __init__(self, a, b):\n            self.a = a\n            self.b = b\n            self.sum = a + b\n            return self.sum\n\nA constructor should not return any value. The `__init__` method should\nonly initialize the values of instance members for news objects.\n\nAs a quick-fix, the IDE offers to remove the `return` statement."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyReturnFromInit",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyMissingOrEmptyDocstringInspection",
-                "shortDescription": {
-                  "text": "Missing or empty docstring"
-                },
-                "fullDescription": {
-                  "text": "Reports missing and empty docstrings. Example of a missing docstring 'def demo(a):\n    c = a ** 2' Example of an empty docstring 'def demo(a):\n    \"\"\"\n    \"\"\"\n    c = a ** 2' When the quick-fix is applied, the code fragments change to: 'def demo(a):\n    \"\"\"\n\n    :param a:\n    \"\"\"\n    c = a ** 2' You need to provide some details about the parameter in the generated template.",
-                  "markdown": "Reports missing and empty docstrings.\n\n**Example of a missing docstring**\n\n\n    def demo(a):\n        c = a ** 2\n\n**Example of an empty docstring**\n\n\n    def demo(a):\n        \"\"\"\n        \"\"\"\n        c = a ** 2\n\nWhen the quick-fix is applied, the code fragments change to:\n\n\n    def demo(a):\n        \"\"\"\n\n        :param a:\n        \"\"\"\n        c = a ** 2\n\nYou need to provide some details about the parameter in the generated template."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyMissingOrEmptyDocstring",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyPep8NamingInspection",
-                "shortDescription": {
-                  "text": "PEP 8 naming convention violation"
-                },
-                "fullDescription": {
-                  "text": "Reports violations of the PEP8 naming conventions. Example: 'class mammalia(object):\n    extremities = 4\n\n    def feeds(self):\n        print(\"milk\")' In this code fragment, IDE offers to rename 'mammalia' to 'Mammalia'. When the quick-fix is applied, the code change to: 'class Mammalia(object):\n    extremities = 4\n\n    def feeds(self):\n        print(\"milk\")'",
-                  "markdown": "Reports violations of the\n[PEP8](https://www.python.org/dev/peps/pep-0008/) naming conventions.\n\n**Example:**\n\n\n    class mammalia(object):\n        extremities = 4\n\n        def feeds(self):\n            print(\"milk\")\n\nIn this code fragment, IDE offers to rename `mammalia` to `Mammalia`.\nWhen the quick-fix is applied, the code change to:\n\n\n    class Mammalia(object):\n        extremities = 4\n\n        def feeds(self):\n            print(\"milk\")\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyPep8Naming",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyDictDuplicateKeysInspection",
-                "shortDescription": {
-                  "text": "Dictionary contains duplicate keys"
-                },
-                "fullDescription": {
-                  "text": "Reports using the same value as the dictionary key twice. Example: 'dic = {\"a\": [1, 2], \"a\": [3, 4]}'",
-                  "markdown": "Reports using the same value as the dictionary key twice.\n\n**Example:**\n\n\n    dic = {\"a\": [1, 2], \"a\": [3, 4]}\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyDictDuplicateKeys",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyNoneFunctionAssignmentInspection",
-                "shortDescription": {
-                  "text": "Assigning function calls that don't return anything"
-                },
-                "fullDescription": {
-                  "text": "Reports cases when an assignment is done on a function that does not return anything. This inspection is similar to pylint inspection E1111. Example: 'def just_print():\n    print(\"Hello!\")\n\n\naction = just_print()' As a quick-fix, the IDE offers to remove the assignment.",
-                  "markdown": "Reports cases when an assignment is done on a function that does not return anything.\nThis inspection is similar to [pylint inspection E1111](https://docs.pylint.org/en/1.6.0/features.html#id6).\n\n**Example:**\n\n\n    def just_print():\n        print(\"Hello!\")\n\n\n    action = just_print()\n\nAs a quick-fix, the IDE offers to remove the assignment."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyNoneFunctionAssignment",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyStatementEffectInspection",
-                "shortDescription": {
-                  "text": "Statement has no effect"
-                },
-                "fullDescription": {
-                  "text": "Reports statements that have no effect. Example: 'class Car:\n    def __init__(self, speed=0):\n        self.speed = speed\n        self.time # has no effect\n\n2 + 3 # has no effect' In this example, you can either add a field 'time' to the 'Car' class or introduce variables for the problematic statements.",
-                  "markdown": "Reports statements that have no effect.\n\n**Example:**\n\n\n    class Car:\n        def __init__(self, speed=0):\n            self.speed = speed\n            self.time # has no effect\n\n    2 + 3 # has no effect\n\nIn this example, you can either add a field `time` to the `Car` class or\nintroduce variables for the problematic statements."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyStatementEffect",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyMandatoryEncodingInspection",
-                "shortDescription": {
-                  "text": "No encoding specified for file"
-                },
-                "fullDescription": {
-                  "text": "Reports a missing encoding comment in Python 2. Example: 'class Book(object):\n    def __init__(self):\n        pass' When the quick-fix is applied, the missing comment is added: '# coding=utf-8\nclass Book(object):\n    def __init__(self):\n        pass'",
-                  "markdown": "Reports a missing encoding comment in Python 2.\n\n**Example:**\n\n\n    class Book(object):\n        def __init__(self):\n            pass\n\nWhen the quick-fix is applied, the missing comment is added:\n\n\n    # coding=utf-8\n    class Book(object):\n        def __init__(self):\n            pass\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyMandatoryEncoding",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyInconsistentIndentationInspection",
-                "shortDescription": {
-                  "text": "Inconsistent indentation"
-                },
-                "fullDescription": {
-                  "text": "Reports inconsistent indentation in Python source files when, for example, you use a mixture of tabs and spaces in your code.",
-                  "markdown": "Reports inconsistent indentation in Python source files when, for example,\nyou use a mixture of tabs and spaces in your code."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyInconsistentIndentation",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyAttributeOutsideInitInspection",
-                "shortDescription": {
-                  "text": "An instance attribute is defined outside `__init__`"
-                },
-                "fullDescription": {
-                  "text": "Reports a problem when instance attribute definition is outside '__init__' method. Example: 'class Book:\n    def __init__(self):\n        self.author = 'Mark Twain'\n\n    def release(self):\n        self.year = '1889'' When the quick-fix is applied, the code sample changes to: 'class Book:\n    def __init__(self):\n        self.year = '1889'\n        self.author = 'Mark Twain'\n\n    def release(self):\n        pass'",
-                  "markdown": "Reports a problem when instance attribute definition is outside `__init__` method.\n\n**Example:**\n\n\n        class Book:\n        def __init__(self):\n            self.author = 'Mark Twain'\n\n        def release(self):\n            self.year = '1889'\n\n\nWhen the quick-fix is applied, the code sample changes to:\n\n\n        class Book:\n        def __init__(self):\n            self.year = '1889'\n            self.author = 'Mark Twain'\n\n        def release(self):\n            pass\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyAttributeOutsideInit",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyTypedDictInspection",
-                "shortDescription": {
-                  "text": "Invalid TypedDict definition and usages"
-                },
-                "fullDescription": {
-                  "text": "Reports invalid definition and usage of TypedDict. Example: 'from typing import TypedDict\n\n\nclass Movie(TypedDict):\n    name: str\n    year: int\n    rate: int = 10  # Right-hand side values are not supported\n\n    def method(self): # Invalid statement in TypedDict\n        pass\n\n\nm = Movie(name=\"name\", year=1000, rate=9)\nprint(m[\"director\"])  # There is no the 'director' key in 'Movie'\ndel m[\"name\"]  # The 'name' key cannot be deleted\nm[\"year\"] = \"1001\"  # Expected 'int', got 'str''",
-                  "markdown": "Reports invalid definition and usage of\n[TypedDict](https://www.python.org/dev/peps/pep-0589/).\n\n**Example:**\n\n\n    from typing import TypedDict\n\n\n    class Movie(TypedDict):\n        name: str\n        year: int\n        rate: int = 10  # Right-hand side values are not supported\n\n        def method(self): # Invalid statement in TypedDict\n            pass\n\n\n    m = Movie(name=\"name\", year=1000, rate=9)\n    print(m[\"director\"])  # There is no the 'director' key in 'Movie'\n    del m[\"name\"]  # The 'name' key cannot be deleted\n    m[\"year\"] = \"1001\"  # Expected 'int', got 'str'\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyTypedDict",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyPep8Inspection",
-                "shortDescription": {
-                  "text": "PEP 8 coding style violation"
-                },
-                "fullDescription": {
-                  "text": "Reports violations of the PEP 8 coding style guide by running the bundled pycodestyle.py tool.",
-                  "markdown": "Reports violations of the [PEP 8 coding style guide](https://www.python.org/dev/peps/pep-0008/) by running the bundled [pycodestyle.py](https://github.com/PyCQA/pycodestyle) tool."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyPep8",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyMissingTypeHintsInspection",
-                "shortDescription": {
-                  "text": "Missing type hinting for function definition"
-                },
-                "fullDescription": {
-                  "text": "Reports missing type hints for function declaration in one of the two formats: parameter annotations or a type comment. Select the Only when types are known checkbox if you want the inspection check the types collected from runtime or inferred.",
-                  "markdown": "Reports missing type hints for function declaration in\none of the two formats: parameter annotations or a type comment.\n\nSelect the **Only when types are known** checkbox if you want the inspection check\nthe types collected from runtime or inferred."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyMissingTypeHints",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyTupleItemAssignmentInspection",
-                "shortDescription": {
-                  "text": "Tuple item assignment is prohibited"
-                },
-                "fullDescription": {
-                  "text": "Reports assignments to a tuple item. Example: 't = ('red', 'blue', 'green', 'white')\nt[3] = 'black'' A quick-fix offers to replace the tuple with a list.",
-                  "markdown": "Reports assignments to a tuple item.\n\n**Example:**\n\n\n    t = ('red', 'blue', 'green', 'white')\n    t[3] = 'black'\n\nA quick-fix offers to replace the tuple with a list."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyTupleItemAssignment",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyDunderSlotsInspection",
-                "shortDescription": {
-                  "text": "Invalid usages of classes with  '__slots__' definitions"
-                },
-                "fullDescription": {
-                  "text": "Reports invalid usages of a class with '__slots__' definitions. Example: 'class Foo:\n    __slots__ = ['foo', 'bar']\n\n\nfoo = Foo()\nfoo.baz = 'spam''",
-                  "markdown": "Reports invalid usages of a class with `__slots__` definitions.\n\n**Example:**\n\n\n    class Foo:\n        __slots__ = ['foo', 'bar']\n\n\n    foo = Foo()\n    foo.baz = 'spam'\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyDunderSlots",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyDefaultArgumentInspection",
-                "shortDescription": {
-                  "text": "The default argument is mutable"
-                },
-                "fullDescription": {
-                  "text": "Reports a problem when a mutable value as a list or dictionary is detected in a default value for an argument. Default argument values are evaluated only once at function definition time, which means that modifying the default value of the argument will affect all subsequent calls of that function. Example: 'def func(s, cache={}):\n    cache[s] = None' When the quick-fix is applied, the code changes to: 'def func(s, cache=None):\n    if cache is None:\n        cache = {}\n    cache[s] = None'",
-                  "markdown": "Reports a problem when a mutable value as a list or dictionary is detected in a default value for\nan argument.   \n\nDefault argument values are evaluated only once at function definition time,\nwhich means that modifying the\ndefault value of the argument will affect all subsequent calls of that function.\n\n**Example:**\n\n\n    def func(s, cache={}):\n        cache[s] = None\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    def func(s, cache=None):\n        if cache is None:\n            cache = {}\n        cache[s] = None\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyDefaultArgument",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyTestUnpassedFixtureInspection",
-                "shortDescription": {
-                  "text": "Fixture is not requested by test functions"
-                },
-                "fullDescription": {
-                  "text": "Reports if a fixture is used without being passed to test function parameters or to '@pytest.mark.usefixtures' decorator",
-                  "markdown": "Reports if a fixture is used without being passed to test function parameters or to `@pytest.mark.usefixtures` decorator"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyTestUnpassedFixture",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyShadowingBuiltinsInspection",
-                "shortDescription": {
-                  "text": "Shadowing built-in names"
-                },
-                "fullDescription": {
-                  "text": "Reports shadowing built-in names, such as 'len' or 'list'. Example: 'def len(a, b, c):\n    d = a + b + c\n    return d' In this code fragment, the 'len' built-in name is used. The IDE offers to apply the Rename refactoring as a fix.",
-                  "markdown": "Reports shadowing built-in names, such as `len` or `list`.\n\n**Example:**\n\n\n    def len(a, b, c):\n        d = a + b + c\n        return d\n\nIn this code fragment, the `len` built-in name is used. The IDE offers to\napply the Rename refactoring as a fix."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyShadowingBuiltins",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyMethodOverridingInspection",
-                "shortDescription": {
-                  "text": "Method signature does not match signature of overridden method"
-                },
-                "fullDescription": {
-                  "text": "Reports inconsistencies in overriding method signatures. Example: 'class Book:\n    def add_title(self):\n        pass\n\n\nclass Novel(Book):\n    def add_title(self, text):\n        pass' Parameters of the 'add_title' method in the 'Novel' class do not match the method signature specified in the 'Book' class. As a fix, the IDE offers to apply the Change Signature refactoring.",
-                  "markdown": "Reports inconsistencies in overriding method signatures.\n\n**Example:**\n\n\n    class Book:\n        def add_title(self):\n            pass\n\n\n    class Novel(Book):\n        def add_title(self, text):\n            pass\n\nParameters of the `add_title` method in the `Novel` class do not match the method\nsignature specified in the `Book` class. As a fix, the IDE offers to apply the Change Signature\nrefactoring."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyMethodOverriding",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PoetryPackageVersionsInspection",
-                "shortDescription": {
-                  "text": "Poetry package versions"
-                },
-                "fullDescription": {
-                  "text": "Reports outdated versions of packages in '[tool.poetry.dependencies]' and '[tool.poetry.dev-dependencies]' sections of 'pyproject.toml'.",
-                  "markdown": "Reports outdated versions of packages in `[tool.poetry.dependencies]` and `[tool.poetry.dev-dependencies]`\nsections of `pyproject.toml`."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PoetryPackageVersions",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyTestParametrizedInspection",
-                "shortDescription": {
-                  "text": "Incorrect arguments in @pytest.mark.parametrize"
-                },
-                "fullDescription": {
-                  "text": "Reports functions that are decorated with @pytest.mark.parametrize but do not have arguments to accept parameters of the decorator.",
-                  "markdown": "Reports functions that are decorated with [@pytest.mark.parametrize](https://docs.pytest.org/en/stable/parametrize.html) but do not have arguments to accept\nparameters of the decorator."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyTestParametrized",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyDecoratorInspection",
-                "shortDescription": {
-                  "text": "Class-specific decorator is used outside the class"
-                },
-                "fullDescription": {
-                  "text": "Reports usages of '@classmethod' or '@staticmethod' decorators in methods outside a class. Example: 'class State(object):\n\n    @classmethod\n    def my_state(cls, name):\n        cls.name = name\n\n\n@classmethod\ndef change_state(self):\n    pass' The 'change_state' method should not use the '@classmethod' decorator or it should be moved to the 'State' class declaration. If you apply the 'Remove decorator' action, the code changes to: 'class State(object):\n\n    @classmethod\n    def my_state(cls, name):\n        cls.name = name\n\n\ndef change_state(self):\n    pass'",
-                  "markdown": "Reports usages of `@classmethod` or `@staticmethod` decorators\nin methods outside a class.\n\n**Example:**\n\n\n    class State(object):\n\n        @classmethod\n        def my_state(cls, name):\n            cls.name = name\n\n\n    @classmethod\n    def change_state(self):\n        pass\n\nThe `change_state` method should not use the `@classmethod` decorator or it should be\nmoved to the `State` class declaration.\n\nIf you apply the `Remove decorator` action, the code changes to:\n\n\n    class State(object):\n\n        @classmethod\n        def my_state(cls, name):\n            cls.name = name\n\n\n    def change_state(self):\n        pass\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyDecorator",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyAsyncCallInspection",
-                "shortDescription": {
-                  "text": "Missing `await` syntax in coroutine calls"
-                },
-                "fullDescription": {
-                  "text": "Reports coroutines that were called without using the 'await' syntax. Example: 'async def bar():\n    pass\n\n\nasync def foo():\n    bar()' After the quick-fix is applied, the code changes to: 'async def bar():\n    pass\n\n\nasync def foo():\n    await bar()'",
-                  "markdown": "Reports coroutines that were called\nwithout using the `await` syntax.\n\n**Example:**\n\n\n    async def bar():\n        pass\n\n\n    async def foo():\n        bar()\n\nAfter the quick-fix is applied, the code changes to:\n\n\n    async def bar():\n        pass\n\n\n    async def foo():\n        await bar()\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyAsyncCall",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "RestRoleInspection",
-                "shortDescription": {
-                  "text": "Role is not defined"
-                },
-                "fullDescription": {
-                  "text": "Reports undefined roles in reStructuredText files. Example: '.. role:: custom\n.. role:: newcustom(emphasis)\n\nAn example of using :custom:`interpreted text`\nAn example of using :newcustom:`interpreted text`\nAn example of using :emphasis:`interpreted text`\n\n\nSome text using undefined role :undef:`interpreted text`'",
-                  "markdown": "Reports undefined roles in reStructuredText files.\n\n**Example:**\n\n\n    .. role:: custom\n    .. role:: newcustom(emphasis)\n\n    An example of using :custom:`interpreted text`\n    An example of using :newcustom:`interpreted text`\n    An example of using :emphasis:`interpreted text`\n\n\n    Some text using undefined role :undef:`interpreted text`\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "RestRoleInspection",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "ReST",
-                      "index": 59,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "CommandLineInspection",
-                "shortDescription": {
-                  "text": "Incorrect CLI syntax"
-                },
-                "fullDescription": {
-                  "text": "Reports the problems if the arguments of the command you type in the console are not in the proper order. The inspection also verifies that option names and arguments are correct. Do not disable the inspection if you are going to use command-line interfaces like manage.py in Django.",
-                  "markdown": "Reports the problems if the arguments of the command you type in the console are not in the proper order. The inspection also verifies\nthat option names and arguments are correct.\n\nDo not disable the inspection if you are going to use command-line interfaces like [manage.py in Django](https://www.jetbrains.com/help/pycharm/running-manage-py.html)."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "CommandLineInspection",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyComparisonWithNoneInspection",
-                "shortDescription": {
-                  "text": "Using equality operators to compare with None"
-                },
-                "fullDescription": {
-                  "text": "Reports comparisons with 'None'. That type of comparisons should always be done with 'is' or 'is not', never the equality operators. Example: 'a = 2\n\n\nif a == None:\n    print(\"Success\")' Once the quick-fix is applied, the code changes to: 'a = 2\n\n\nif a is None:\n    print(\"Success\")'",
-                  "markdown": "Reports comparisons with `None`. That type of comparisons\nshould always be done with `is` or `is not`, never\nthe equality operators.\n\n**Example:**\n\n\n    a = 2\n\n\n    if a == None:\n        print(\"Success\")\n\nOnce the quick-fix is applied, the code changes to:\n\n\n    a = 2\n\n\n    if a is None:\n        print(\"Success\")\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyComparisonWithNone",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyMethodParametersInspection",
-                "shortDescription": {
-                  "text": "Improper first parameter"
-                },
-                "fullDescription": {
-                  "text": "Reports methods that lack the first parameter that is usually named 'self'. Example: 'class Movie:\n\n   def show():\n       pass' When the quick-fix is applied, the code changes to: 'class Movie:\n\n   def show(self):\n       pass' The inspection also reports naming issues in class methods. Example: 'class Movie:\n    @classmethod\n    def show(abc):\n        pass' Since the first parameter of a class method should be 'cls', the IDE provides a quick-fix to rename it.",
-                  "markdown": "Reports methods that lack the first parameter that is usually\nnamed `self`.\n\n**Example:**\n\n\n    class Movie:\n\n       def show():\n           pass\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    class Movie:\n\n       def show(self):\n           pass\n\nThe inspection also reports naming issues in class methods.\n\n**Example:**\n\n\n    class Movie:\n        @classmethod\n        def show(abc):\n            pass\n\nSince the first parameter of a class method should be `cls`, the IDE provides a quick-fix\nto rename it."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyMethodParameters",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyDocstringTypesInspection",
-                "shortDescription": {
-                  "text": "Type in docstring does not match inferred type"
-                },
-                "fullDescription": {
-                  "text": "Reports types in docstring that do not match dynamically inferred types.",
-                  "markdown": "Reports types in docstring that do not match dynamically inferred types."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyDocstringTypes",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyMethodFirstArgAssignmentInspection",
-                "shortDescription": {
-                  "text": "First argument of the method is reassigned"
-                },
-                "fullDescription": {
-                  "text": "Reports cases when the first parameter, such as 'self' or 'cls', is reassigned in a method. Because in most cases, there are no objectives in such reassignment, the IDE indicates an error. Example: 'class Account:\n    def calc(self, balance):\n        if balance == 0:\n            self = balance\n        return self' As a fix, you might want to check and modify the algorithm to ensure that reassignment is needed. If everything is correct, you can invoke intention actions for this code and opt to ignore the warning.",
-                  "markdown": "Reports cases when the first parameter,\nsuch as `self` or `cls`, is reassigned in a method.\nBecause in most cases, there are no objectives in such reassignment, the\nIDE indicates an error.\n\n**Example:**\n\n\n    class Account:\n        def calc(self, balance):\n            if balance == 0:\n                self = balance\n            return self\n\nAs a fix, you might want to check and modify the algorithm to ensure that reassignment is needed. If everything is correct,\nyou can invoke intention actions for this code and opt to ignore the warning."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyMethodFirstArgAssignment",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyNewStyleGenericSyntaxInspection",
-                "shortDescription": {
-                  "text": "Invalid usage of new-style type parameters and type aliases"
-                },
-                "fullDescription": {
-                  "text": "Reports invalid usage of PEP 695 type parameter syntax Finds the following problems in function and class definitions and new-style type alias statements: Extending typing.Generic in new-style generic classes Extending parameterized typing.Protocol in new-style generic classes Using generic upper bounds and constraints with type parameters for ParamSpec and TypeVarTuple Mixing traditional and new-style type variables Using traditional type variables in new-style type aliases Examples: 'from typing import Generic\n\n  class Example[T](Generic[T]): ... # Classes with type parameter list should not extend 'Generic'' 'class Example[T: (list[S], str)]: ... # Generic types are not allowed inside constraints and bounds of type parameters' 'from typing import TypeVar\n\n  K = TypeVar(\"K\")\n\n  class ClassC[V]:\n      def method2[M](self, a: M, b: K) -> M | K: ... # Mixing traditional and new-style TypeVars is not allowed'",
-                  "markdown": "Reports invalid usage of [PEP 695](https://www.python.org/dev/peps/pep-0695/) type parameter syntax\n\n\nFinds the following problems in function and class definitions and new-style type alias statements:\n\n* Extending typing.Generic in new-style generic classes\n* Extending parameterized typing.Protocol in new-style generic classes\n* Using generic upper bounds and constraints with type parameters for ParamSpec and TypeVarTuple\n* Mixing traditional and new-style type variables\n* Using traditional type variables in new-style type aliases\n\n\nExamples:\n\n\n      from typing import Generic\n\n      class Example[T](Generic[T]): ... # Classes with type parameter list should not extend 'Generic'\n\n\n      class Example[T: (list[S], str)]: ... # Generic types are not allowed inside constraints and bounds of type parameters\n\n\n      from typing import TypeVar\n\n      K = TypeVar(\"K\")\n\n      class ClassC[V]:\n          def method2[M](self, a: M, b: K) -> M | K: ... # Mixing traditional and new-style TypeVars is not allowed\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyNewStyleGenericSyntax",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyTupleAssignmentBalanceInspection",
-                "shortDescription": {
-                  "text": "Tuple assignment balance is incorrect"
-                },
-                "fullDescription": {
-                  "text": "Reports cases when the number of expressions on the right-hand side and targets on the left-hand side are not the same. Example: 't = ('red', 'blue', 'green', 'white')\n(c1, c2, c3) = t' As a quick-fix, you can modify the highlighted code fragment to restore the tuple balance.",
-                  "markdown": "Reports cases when the number of expressions on the right-hand side\nand targets on the left-hand side are not the same.\n\n**Example:**\n\n\n    t = ('red', 'blue', 'green', 'white')\n    (c1, c2, c3) = t\n\nAs a quick-fix, you can modify the highlighted code fragment to restore the tuple\nbalance."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyTupleAssignmentBalance",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyClassHasNoInitInspection",
-                "shortDescription": {
-                  "text": "Class has no `__init__` method"
-                },
-                "fullDescription": {
-                  "text": "Reports cases in Python 2 when a class has no '__init__' method, neither its parent classes. Example: 'class Book():\n    pass' The quick-fix adds the '__init__' method: 'class Book():\n    def __init__(self):\n        pass'",
-                  "markdown": "Reports cases in Python 2 when a class has no `__init__` method, neither its parent\nclasses.\n\n**Example:**\n\n\n    class Book():\n        pass\n\nThe quick-fix adds the `__init__` method:\n\n\n    class Book():\n        def __init__(self):\n            pass\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyClassHasNoInit",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyArgumentEqualDefaultInspection",
-                "shortDescription": {
-                  "text": "The function argument is equal to the default parameter value"
-                },
-                "fullDescription": {
-                  "text": "Reports a problem when an argument passed to the function is equal to the default parameter value. This inspection is disabled by default to avoid performance degradation. Example: 'def my_function(a: int = 2):\n    print(a)\n\n\nmy_function(2)'",
-                  "markdown": "Reports a problem when an argument\npassed to the function is equal to the default parameter value.\n\nThis inspection is disabled by default to avoid performance degradation.\n\n**Example:**\n\n\n    def my_function(a: int = 2):\n        print(a)\n\n\n    my_function(2)\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyArgumentEqualDefault",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyClassVarInspection",
-                "shortDescription": {
-                  "text": "Invalid usage of ClassVar variables"
-                },
-                "fullDescription": {
-                  "text": "Reports invalid usages of ClassVar annotations. Example: 'from typing import ClassVar\n\n\nclass Cat:\n    color: ClassVar[str] = \"white\"\n    weight: int\n\n    def __init__(self, weight: int):\n        self.weight = weight\n\n\nCat.color = \"black\"  # OK\nmy_cat = Cat(5)\nmy_cat.color = \"gray\"  # Error, setting class variable on instance'",
-                  "markdown": "Reports invalid usages of [ClassVar](https://docs.python.org/3/library/typing.html#typing.ClassVar) annotations.\n\n**Example:**\n\n\n    from typing import ClassVar\n\n\n    class Cat:\n        color: ClassVar[str] = \"white\"\n        weight: int\n\n        def __init__(self, weight: int):\n            self.weight = weight\n\n\n    Cat.color = \"black\"  # OK\n    my_cat = Cat(5)\n    my_cat.color = \"gray\"  # Error, setting class variable on instance\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyClassVar",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyFromFutureImportInspection",
-                "shortDescription": {
-                  "text": "Improper position of from __future__ import"
-                },
-                "fullDescription": {
-                  "text": "Reports 'from __future__ import' statements that are used not at the beginning of a file. Example: 'a = 1\nfrom __future__ import print_function\nprint()' When the quick-fix is applied, the code changes to: 'from __future__ import print_function\n\na = 1\nprint()'",
-                  "markdown": "Reports `from __future__ import`\nstatements that are used not at\nthe beginning of a file.\n\n**Example:**\n\n\n    a = 1\n    from __future__ import print_function\n    print()\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    from __future__ import print_function\n\n    a = 1\n    print()\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyFromFutureImport",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyUnresolvedReferencesInspection",
-                "shortDescription": {
-                  "text": "Unresolved references"
-                },
-                "fullDescription": {
-                  "text": "Reports references in your code that cannot be resolved. In a dynamically typed language, this is possible in a limited number of cases. If a reference type is unknown, then its attributes are not highlighted as unresolved even if you know that they should be: 'def print_string(s):\n  print(s.abc())' In this code fragment 's' is always a string and 'abc' should be highlighted as unresolved. However, 's' type is inferred as 'Any' and no warning is reported. The IDE provides quick-fix actions to add missing references on-the-fly.",
-                  "markdown": "Reports references in your code that cannot be resolved.\n\nIn a dynamically typed language, this is possible in a limited number of cases.\n\nIf a reference type is unknown, then its attributes are not highlighted as unresolved even if you know that they should be:\n\n\n    def print_string(s):\n      print(s.abc())\n\nIn this code fragment `s` is always a string and `abc` should be highlighted as unresolved. However, `s`\ntype is inferred as `Any` and no warning is reported.\n\nThe IDE provides quick-fix actions to add missing references on-the-fly."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyUnresolvedReferences",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyPackageRequirementsInspection",
-                "shortDescription": {
-                  "text": "Unsatisfied package requirements"
-                },
-                "fullDescription": {
-                  "text": "Reports packages mentioned in requirements files (for example, 'requirements.txt' or 'Pipfile') but not installed, or imported but not mentioned in requirements files. The IDE shows a quick-fix banner so that you can install the missing packages in one click.",
-                  "markdown": "Reports packages mentioned in requirements files (for example, `requirements.txt` or `Pipfile`) but not installed,\nor imported but not mentioned in requirements files.\n\n\nThe IDE shows a quick-fix banner so that you can install the missing packages in one click."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyPackageRequirements",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyRedundantParenthesesInspection",
-                "shortDescription": {
-                  "text": "Redundant parentheses"
-                },
-                "fullDescription": {
-                  "text": "Reports about redundant parentheses in expressions. The IDE provides the quick-fix action to remove the redundant parentheses.",
-                  "markdown": "Reports about redundant parentheses in expressions.\n\nThe IDE provides the quick-fix action to remove the redundant parentheses."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyRedundantParentheses",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyTrailingSemicolonInspection",
-                "shortDescription": {
-                  "text": "Prohibited trailing semicolon in a statement"
-                },
-                "fullDescription": {
-                  "text": "Reports trailing semicolons in statements. Example: 'def my_func(a):\n    c = a ** 2;\n    return c' IDE provides a quick-fix that removes a trailing semicolon. When you apply it, the code changes to: 'def my_func(a):\n    c = a ** 2\n    return c'",
-                  "markdown": "Reports trailing semicolons in statements.\n\n**Example:**\n\n\n    def my_func(a):\n        c = a ** 2;\n        return c\n\nIDE provides a quick-fix that removes a trailing semicolon. When you\napply it, the code changes to:\n\n\n    def my_func(a):\n        c = a ** 2\n        return c\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyTrailingSemicolon",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyArgumentListInspection",
-                "shortDescription": {
-                  "text": "Incorrect call arguments"
-                },
-                "fullDescription": {
-                  "text": "Reports discrepancies between declared parameters and actual arguments, as well as incorrect arguments, for example, duplicate named arguments, and incorrect argument order. Example: 'class Foo:\n    def __call__(self, p1: int, *, p2: str = \"%\"):\n        return p2 * p1\n\n\nbar = Foo()\nbar.__call__() # unfilled parameter\nbar(5, \"#\") # unexpected argument' The correct code fragment looks at follows: 'class Foo:\n    def __call__(self, p1: int, *, p2: str = \"%\"):\n        return p2 * p1\n\n\nbar = Foo()\nbar.__call__(5)\nbar(5, p2=\"#\")'",
-                  "markdown": "Reports discrepancies between declared parameters and actual arguments, as well as\nincorrect arguments, for example, duplicate named arguments, and incorrect argument order.\n\n**Example:**\n\n\n    class Foo:\n        def __call__(self, p1: int, *, p2: str = \"%\"):\n            return p2 * p1\n\n\n    bar = Foo()\n    bar.__call__() # unfilled parameter\n    bar(5, \"#\") # unexpected argument\n\nThe correct code fragment looks at follows:\n\n\n    class Foo:\n        def __call__(self, p1: int, *, p2: str = \"%\"):\n            return p2 * p1\n\n\n    bar = Foo()\n    bar.__call__(5)\n    bar(5, p2=\"#\")\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyArgumentList",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyInterpreterInspection",
-                "shortDescription": {
-                  "text": "An invalid interpreter"
-                },
-                "fullDescription": {
-                  "text": "Reports problems if there is no Python interpreter configured for the project or if the interpreter is invalid. Without a properly configured interpreter, you cannot execute your Python scripts and benefit from some Python code insight features. The IDE provides quick access to the interpreter settings.",
-                  "markdown": "Reports problems if there is no Python interpreter configured for the project or if the interpreter is invalid. Without a properly\nconfigured interpreter, you cannot execute your Python scripts and benefit from some Python code insight features.\n\nThe IDE provides quick access to the interpreter settings."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyInterpreter",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyPropertyAccessInspection",
-                "shortDescription": {
-                  "text": "Inappropriate access to properties"
-                },
-                "fullDescription": {
-                  "text": "Reports cases when properties are accessed inappropriately: Read-only properties are set Write-only properties are read Non-deletable properties are deleted Example: 'class MyClass:\n    @property\n    def read_only(self): return None\n\n    def __write_only_setter(self, value): pass\n\n    write_only = property(None, __write_only_setter)\n\n\na = MyClass()\na.read_only = 10 # property cannot be set\ndel a.read_only # property cannot be deleted\nprint(a.write_only) # property cannot be read'",
-                  "markdown": "Reports cases when properties are accessed inappropriately:\n\n* Read-only properties are set\n* Write-only properties are read\n* Non-deletable properties are deleted\n\n**Example:**\n\n\n    class MyClass:\n        @property\n        def read_only(self): return None\n\n        def __write_only_setter(self, value): pass\n\n        write_only = property(None, __write_only_setter)\n\n\n    a = MyClass()\n    a.read_only = 10 # property cannot be set\n    del a.read_only # property cannot be deleted\n    print(a.write_only) # property cannot be read\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyPropertyAccess",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyStubPackagesAdvertiser",
-                "shortDescription": {
-                  "text": "Stub packages advertiser"
-                },
-                "fullDescription": {
-                  "text": "Reports availability of stub packages. Stub package is a package that contains type information for the corresponding runtime package. Using stub packages ensures better coding assistance for the corresponding python package.",
-                  "markdown": "Reports availability of stub packages.\n\n\n[Stub package](https://www.python.org/dev/peps/pep-0561/) is a package that contains type information for the corresponding\nruntime package.\n\nUsing stub packages ensures better coding assistance for the corresponding python package."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyStubPackagesAdvertiser",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyRelativeImportInspection",
-                "shortDescription": {
-                  "text": "Suspicious relative imports"
-                },
-                "fullDescription": {
-                  "text": "Reports usages of relative imports inside plain directories, for example, directories neither containing '__init__.py' nor explicitly marked as namespace packages.",
-                  "markdown": "Reports usages of relative imports inside plain directories, for example, directories neither containing `__init__.py` nor\nexplicitly marked as namespace packages."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyPackages",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyRedeclarationInspection",
-                "shortDescription": {
-                  "text": "Redeclared names without usages"
-                },
-                "fullDescription": {
-                  "text": "Reports unconditional redeclarations of names without being used in between. Example: 'def x(): pass\n\n\nx = 2' It applies to function and class declarations, and top-level assignments. When the warning is shown, you can try a recommended action, for example, you might be prompted to rename the variable.",
-                  "markdown": "Reports unconditional redeclarations of names without being used in between.\n\n**Example:**\n\n\n    def x(): pass\n\n\n    x = 2\n\nIt applies to function and class declarations, and top-level assignments.\n\nWhen the warning is shown, you can try a recommended action, for example, you might be prompted to\nrename the variable."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyRedeclaration",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyramidSetupInspection",
-                "shortDescription": {
-                  "text": "Project is not installed for development"
-                },
-                "fullDescription": {
-                  "text": "Reports cases when no 'python setup.py develop' command was executed for the Pyramid project. You need to execute this command to install the newly created project for development.",
-                  "markdown": "Reports cases when no `python setup.py develop` command was executed for the Pyramid project.\n\nYou need to execute this command to install the newly created project for development."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyramidSetup",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Pyramid",
-                      "index": 63,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyStubPackagesCompatibilityInspection",
-                "shortDescription": {
-                  "text": "Incompatible stub packages"
-                },
-                "fullDescription": {
-                  "text": "Reports stub packages that do not support the version of the corresponding runtime package. A stub package contains type information for some runtime package.",
-                  "markdown": "Reports stub packages that do not support the version of the corresponding runtime package.\n\nA [stub package](https://www.python.org/dev/peps/pep-0561/) contains type information for some runtime package."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyStubPackagesCompatibility",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyProtectedMemberInspection",
-                "shortDescription": {
-                  "text": "Accessing a protected member of a class or a module"
-                },
-                "fullDescription": {
-                  "text": "Reports cases when a protected member is accessed outside the class, a descendant of the class where it is defined, or a module. Example: 'class Foo:\n    def _protected_method(self):\n        pass\n\n\nclass Bar(Foo):\n    def public_method(self):\n        self._protected_method()\n\n\nfoo = Foo()\nfoo._protected_method() # Access to a protected method'",
-                  "markdown": "Reports cases when a protected member is accessed outside the class,\na descendant of the class where it is defined, or a module.\n\n**Example:**\n\n\n    class Foo:\n        def _protected_method(self):\n            pass\n\n\n    class Bar(Foo):\n        def public_method(self):\n            self._protected_method()\n\n\n    foo = Foo()\n    foo._protected_method() # Access to a protected method\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyProtectedMember",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyUnboundLocalVariableInspection",
-                "shortDescription": {
-                  "text": "Unbound local variables"
-                },
-                "fullDescription": {
-                  "text": "Reports local variables referenced before assignment. Example: 'x = 0\nif x > 10:\n    b = 3\nprint(b)' The IDE reports a problem for 'print(b)'. A possible fix is: 'x = 0\nif x > 10:\n    b = 3\n    print(b)'",
-                  "markdown": "Reports local variables referenced before assignment.\n\n**Example:**\n\n\n    x = 0\n    if x > 10:\n        b = 3\n    print(b)\n\nThe IDE reports a problem for `print(b)`. A possible fix is:\n\n\n    x = 0\n    if x > 10:\n        b = 3\n        print(b)\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyUnboundLocalVariable",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyNamedTupleInspection",
-                "shortDescription": {
-                  "text": "Invalid definition of 'typing.NamedTuple'"
-                },
-                "fullDescription": {
-                  "text": "Reports invalid definition of a typing.NamedTuple. Example: 'import typing\n\n\nclass FullName(typing.NamedTuple):\n    first: str\n    last: str = \"\"\n    middle: str' As a fix, place the field with the default value after the fields without default values: 'import typing\n\n\nclass FullName(typing.NamedTuple):\n    first: str\n    middle: str\n    last: str = \"\"'",
-                  "markdown": "Reports invalid definition of a\n[typing.NamedTuple](https://docs.python.org/3/library/typing.html#typing.NamedTuple).\n\n**Example:**\n\n\n    import typing\n\n\n    class FullName(typing.NamedTuple):\n        first: str\n        last: str = \"\"\n        middle: str\n\nAs a fix, place the field with the default value after the fields without default values:\n\n\n    import typing\n\n\n    class FullName(typing.NamedTuple):\n        first: str\n        middle: str\n        last: str = \"\"\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyNamedTuple",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyNestedDecoratorsInspection",
-                "shortDescription": {
-                  "text": "Problematic nesting of decorators"
-                },
-                "fullDescription": {
-                  "text": "Reports problems with nesting decorators. The inspection highlights the cases when 'classmethod' or 'staticmethod' is applied before another decorator. Example: 'def innocent(f):\n    return f\n\n\nclass A:\n    @innocent  # Decorator will not receive a callable it may expect\n    @classmethod\n    def f2(cls):\n        pass\n\n    @innocent  # Decorator will not receive a callable it may expect\n    @staticmethod\n    def f1():\n        pass' As a quick-fix, the IDE offers to remove the decorator.",
-                  "markdown": "Reports problems with nesting decorators. The inspection highlights the cases when `classmethod` or `staticmethod`\nis applied before another decorator.\n\n**Example:**\n\n\n    def innocent(f):\n        return f\n\n\n    class A:\n        @innocent  # Decorator will not receive a callable it may expect\n        @classmethod\n        def f2(cls):\n            pass\n\n        @innocent  # Decorator will not receive a callable it may expect\n        @staticmethod\n        def f1():\n            pass\n\nAs a quick-fix, the IDE offers to remove the decorator."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyNestedDecorators",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyOverloadsInspection",
-                "shortDescription": {
-                  "text": "Overloads in regular Python files"
-                },
-                "fullDescription": {
-                  "text": "Reports cases when overloads in regular Python files are placed after the implementation or when their signatures are not compatible with the implementation. Example: 'from typing import overload\n\n\n@overload\ndef foo(p1, p2): # Overload signature is not compatible with the implementation\n    pass\n\n\n@overload\ndef foo(p1): # Overload signature is not compatible with the implementation\n    pass\n\n\ndef foo(p1, p2, p3):\n    print(p1, p2, p3)'",
-                  "markdown": "Reports cases when overloads in regular Python files are placed after the implementation or when their signatures are\nnot compatible with the implementation.\n\n**Example:**\n\n\n    from typing import overload\n\n\n    @overload\n    def foo(p1, p2): # Overload signature is not compatible with the implementation\n        pass\n\n\n    @overload\n    def foo(p1): # Overload signature is not compatible with the implementation\n        pass\n\n\n    def foo(p1, p2, p3):\n        print(p1, p2, p3)\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyOverloads",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyExceptClausesOrderInspection",
-                "shortDescription": {
-                  "text": "Wrong order of 'except' clauses"
-                },
-                "fullDescription": {
-                  "text": "Reports cases when 'except' clauses are not in the proper order, from the more specific to the more generic, or one exception class is caught twice. If you do not fix the order, some exceptions may not be caught by the most specific handler. Example: 'try:\n    call()\nexcept ValueError:\n    pass\nexcept UnicodeError:\n    pass' The IDE recommends moving the clause up. When the quick-fix is applied, the code changes to: 'try:\n    call()\nexcept UnicodeError:\n    pass\nexcept ValueError:\n    pass'",
-                  "markdown": "Reports cases when `except` clauses are not in the proper order,\nfrom the more specific to the more generic, or one exception class is caught twice.\n\n\nIf you do not fix the order, some exceptions may not be caught by the most specific handler.\n\n**Example:**\n\n\n    try:\n        call()\n    except ValueError:\n        pass\n    except UnicodeError:\n        pass\n\nThe IDE recommends moving the clause up. When the quick-fix is applied, the code changes to:\n\n\n    try:\n        call()\n    except UnicodeError:\n        pass\n    except ValueError:\n        pass\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyExceptClausesOrder",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyDataclassInspection",
-                "shortDescription": {
-                  "text": "Invalid definition and usage of Data Classes"
-                },
-                "fullDescription": {
-                  "text": "Reports invalid definitions and usages of classes created with 'dataclasses' or 'attr' modules. Example: 'import dataclasses\n\n\n@dataclasses.dataclass\nclass FullName:\n    first: str\n    middle: str = \"\"\n    last: str'",
-                  "markdown": "Reports invalid definitions and usages of classes created with\n`dataclasses` or `attr` modules.\n\n**Example:**\n\n\n    import dataclasses\n\n\n    @dataclasses.dataclass\n    class FullName:\n        first: str\n        middle: str = \"\"\n        last: str\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyDataclass",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyClassicStyleClassInspection",
-                "shortDescription": {
-                  "text": "Classic style class usage"
-                },
-                "fullDescription": {
-                  "text": "Reports classic style classes usage. This inspection applies only to Python 2. Example: 'class A:\n    pass' With quick-fixes provided by the IDE, this code fragment changes to: 'class A(object):\n    def __init__(self):\n        pass'",
-                  "markdown": "Reports [classic style classes](https://docs.python.org/2/reference/datamodel.html#new-style-and-classic-classes) usage. This inspection applies only to Python 2.\n\n**Example:**\n\n\n    class A:\n        pass\n\nWith quick-fixes provided by the IDE, this code fragment changes to:\n\n\n    class A(object):\n        def __init__(self):\n            pass\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyClassicStyleClass",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyPropertyDefinitionInspection",
-                "shortDescription": {
-                  "text": "Incorrect property definition"
-                },
-                "fullDescription": {
-                  "text": "Reports problems with the arguments of 'property()' and functions annotated with '@property'. 'class C:\n    @property\n    def abc(self):  # Getter should return or yield something\n        pass\n\n    @abc.setter\n    def foo(self, value):  # Names of function and decorator don't match\n        pass\n\n    @abc.setter\n    def abc(self, v1, v2):  # Setter signature should be (self, value)\n        pass\n\n    @abc.deleter\n    def abc(self, v1):  # Delete signature should be (self)\n        pass' A quick-fix offers to update parameters.",
-                  "markdown": "Reports problems with the arguments of `property()` and functions\nannotated with `@property`.\n\n\n    class C:\n        @property\n        def abc(self):  # Getter should return or yield something\n            pass\n\n        @abc.setter\n        def foo(self, value):  # Names of function and decorator don't match\n            pass\n\n        @abc.setter\n        def abc(self, v1, v2):  # Setter signature should be (self, value)\n            pass\n\n        @abc.deleter\n        def abc(self, v1):  # Delete signature should be (self)\n            pass\n\nA quick-fix offers to update parameters."
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PyPropertyDefinition",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyIncorrectDocstringInspection",
-                "shortDescription": {
-                  "text": "Incorrect docstring"
-                },
-                "fullDescription": {
-                  "text": "Reports mismatched parameters in a docstring. For example, 'b' is highlighted, because there is no such a parameter in the 'add' function. 'def add(a, c):\n    \"\"\"\n    @param a:\n    @param b:\n    @return:\n    \"\"\"\n    pass' The inspection does not warn you of missing parameters if none of them is mentioned in a docstring: 'def mult(a, c):\n    \"\"\"\n    @return:\n    \"\"\"\n    pass'",
-                  "markdown": "Reports mismatched parameters in a docstring. For example, `b` is highlighted, because there is no\nsuch a parameter in the `add` function.\n\n\n        def add(a, c):\n        \"\"\"\n        @param a:\n        @param b:\n        @return:\n        \"\"\"\n        pass\n\nThe inspection does not warn you of missing parameters if none of them is mentioned in a docstring:\n\n\n    def mult(a, c):\n        \"\"\"\n        @return:\n        \"\"\"\n        pass\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyIncorrectDocstring",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "PyListCreationInspection",
-                "shortDescription": {
-                  "text": "Non-optimal list declaration"
-                },
-                "fullDescription": {
-                  "text": "Reports cases when a list declaration can be rewritten with a list literal. This ensures better performance of your application. Example: 'l = [1]\nl.append(2)' When the quick-fix is applied, the code changes to: 'l = [1, 2]'",
-                  "markdown": "Reports cases when a list declaration\ncan be rewritten with a list literal.\n\nThis ensures better performance of your application.\n\n**Example:**\n\n\n    l = [1]\n    l.append(2)\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    l = [1, 2]\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "PyListCreation",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "Python",
-                      "index": 1,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              }
-            ],
-            "language": "en-US",
-            "contents": [
-              "localizedData",
-              "nonLocalizedData"
-            ],
-            "isComprehensive": false
-          },
-          {
             "name": "JavaScript",
             "version": "241.17568",
             "rules": [
@@ -4735,7 +751,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -4769,6 +785,39 @@
                     "target": {
                       "id": "JavaScript and TypeScript/Unit testing",
                       "index": 7,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "IfStatementWithTooManyBranchesJS",
+                "shortDescription": {
+                  "text": "'if' statement with too many branches"
+                },
+                "fullDescription": {
+                  "text": "Reports an 'if' statement with too many branches. Such statements may be confusing, and often indicate inadequate levels of design abstraction. Use the field below to specify the maximum number of branches expected.",
+                  "markdown": "Reports an `if` statement with too many branches. Such statements may be confusing, and often indicate inadequate levels of design abstraction.\n\n\nUse the field below to specify the maximum number of branches expected."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "IfStatementWithTooManyBranchesJS",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JavaScript and TypeScript/Control flow issues",
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -4835,39 +884,6 @@
                     "target": {
                       "id": "JavaScript and TypeScript/General",
                       "index": 11,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "IfStatementWithTooManyBranchesJS",
-                "shortDescription": {
-                  "text": "'if' statement with too many branches"
-                },
-                "fullDescription": {
-                  "text": "Reports an 'if' statement with too many branches. Such statements may be confusing, and often indicate inadequate levels of design abstraction. Use the field below to specify the maximum number of branches expected.",
-                  "markdown": "Reports an `if` statement with too many branches. Such statements may be confusing, and often indicate inadequate levels of design abstraction.\n\n\nUse the field below to specify the maximum number of branches expected."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "IfStatementWithTooManyBranchesJS",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -5164,7 +1180,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -5626,7 +1642,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -5758,7 +1774,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -6199,39 +2215,6 @@
                 ]
               },
               {
-                "id": "PointlessBooleanExpressionJS",
-                "shortDescription": {
-                  "text": "Pointless statement or boolean expression"
-                },
-                "fullDescription": {
-                  "text": "Reports a pointless or pointlessly complicated boolean expression or statement. Example: 'let a = !(false && x);\n  let b = false || x;' After the quick fix is applied the result looks like: 'let a = true;\n  let b = x;'",
-                  "markdown": "Reports a pointless or pointlessly complicated boolean expression or statement.\n\nExample:\n\n\n      let a = !(false && x);\n      let b = false || x;\n\nAfter the quick fix is applied the result looks like:\n\n\n      let a = true;\n      let b = x;\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "PointlessBooleanExpressionJS",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
                 "id": "JSReferencingMutableVariableFromClosure",
                 "shortDescription": {
                   "text": "Referencing mutable variable from closure"
@@ -6254,6 +2237,39 @@
                     "target": {
                       "id": "JavaScript and TypeScript/General",
                       "index": 11,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PointlessBooleanExpressionJS",
+                "shortDescription": {
+                  "text": "Pointless statement or boolean expression"
+                },
+                "fullDescription": {
+                  "text": "Reports a pointless or pointlessly complicated boolean expression or statement. Example: 'let a = !(false && x);\n  let b = false || x;' After the quick fix is applied the result looks like: 'let a = true;\n  let b = x;'",
+                  "markdown": "Reports a pointless or pointlessly complicated boolean expression or statement.\n\nExample:\n\n\n      let a = !(false && x);\n      let b = false || x;\n\nAfter the quick fix is applied the result looks like:\n\n\n      let a = true;\n      let b = x;\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PointlessBooleanExpressionJS",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JavaScript and TypeScript/Control flow issues",
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -6385,7 +2401,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -6727,39 +2743,6 @@
                 ]
               },
               {
-                "id": "JSConstantReassignment",
-                "shortDescription": {
-                  "text": "Attempt to assign to const or readonly variable"
-                },
-                "fullDescription": {
-                  "text": "Reports reassigning a value to a constant or a readonly variable.",
-                  "markdown": "Reports reassigning a value to a constant or a readonly variable."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "error",
-                  "parameters": {
-                    "suppressToolId": "JSConstantReassignment",
-                    "ideaSeverity": "ERROR",
-                    "qodanaSeverity": "Critical"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "JavaScript and TypeScript/Validity issues",
-                      "index": 27,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
                 "id": "TypeScriptCheckImport",
                 "shortDescription": {
                   "text": "Unresolved imported name"
@@ -6782,6 +2765,39 @@
                     "target": {
                       "id": "JavaScript and TypeScript/TypeScript",
                       "index": 26,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "JSConstantReassignment",
+                "shortDescription": {
+                  "text": "Attempt to assign to const or readonly variable"
+                },
+                "fullDescription": {
+                  "text": "Reports reassigning a value to a constant or a readonly variable.",
+                  "markdown": "Reports reassigning a value to a constant or a readonly variable."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "JSConstantReassignment",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JavaScript and TypeScript/Validity issues",
+                      "index": 27,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -7123,39 +3139,6 @@
                 ]
               },
               {
-                "id": "AnonymousFunctionJS",
-                "shortDescription": {
-                  "text": "Anonymous function"
-                },
-                "fullDescription": {
-                  "text": "Reports an anonymous function. An explicit name of a function expression may be helpful for debugging. Ignores function expressions without names if they have a 'name' property specified in the ECMAScript 6 standard. For example, 'var bar = function() {};' is not reported.",
-                  "markdown": "Reports an anonymous function. An explicit name of a function expression may be helpful for debugging. Ignores function expressions without names if they have a `name` property specified in the ECMAScript 6 standard. For example, `var bar = function() {};` is not reported."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "AnonymousFunctionJS",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "JavaScript and TypeScript/Potentially undesirable code constructs",
-                      "index": 14,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
                 "id": "BlockStatementJS",
                 "shortDescription": {
                   "text": "Unnecessary block statement"
@@ -7178,6 +3161,39 @@
                     "target": {
                       "id": "JavaScript and TypeScript/Potentially confusing code constructs",
                       "index": 28,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "AnonymousFunctionJS",
+                "shortDescription": {
+                  "text": "Anonymous function"
+                },
+                "fullDescription": {
+                  "text": "Reports an anonymous function. An explicit name of a function expression may be helpful for debugging. Ignores function expressions without names if they have a 'name' property specified in the ECMAScript 6 standard. For example, 'var bar = function() {};' is not reported.",
+                  "markdown": "Reports an anonymous function. An explicit name of a function expression may be helpful for debugging. Ignores function expressions without names if they have a `name` property specified in the ECMAScript 6 standard. For example, `var bar = function() {};` is not reported."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "AnonymousFunctionJS",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JavaScript and TypeScript/Potentially undesirable code constructs",
+                      "index": 14,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -7255,39 +3271,6 @@
                 ]
               },
               {
-                "id": "NestedConditionalExpressionJS",
-                "shortDescription": {
-                  "text": "Nested conditional expression"
-                },
-                "fullDescription": {
-                  "text": "Reports a ternary conditional expression within another ternary condition. Such nested conditionals may be extremely confusing, and best replaced by more explicit conditional logic.",
-                  "markdown": "Reports a ternary conditional expression within another ternary condition. Such nested conditionals may be extremely confusing, and best replaced by more explicit conditional logic."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "NestedConditionalExpressionJS",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "JavaScript and TypeScript/Potentially confusing code constructs",
-                      "index": 28,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
                 "id": "JSTypeOfValues",
                 "shortDescription": {
                   "text": "'typeof' comparison with non-standard value"
@@ -7310,6 +3293,39 @@
                     "target": {
                       "id": "JavaScript and TypeScript/Probable bugs",
                       "index": 16,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "NestedConditionalExpressionJS",
+                "shortDescription": {
+                  "text": "Nested conditional expression"
+                },
+                "fullDescription": {
+                  "text": "Reports a ternary conditional expression within another ternary condition. Such nested conditionals may be extremely confusing, and best replaced by more explicit conditional logic.",
+                  "markdown": "Reports a ternary conditional expression within another ternary condition. Such nested conditionals may be extremely confusing, and best replaced by more explicit conditional logic."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "NestedConditionalExpressionJS",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JavaScript and TypeScript/Potentially confusing code constructs",
+                      "index": 28,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -7354,39 +3370,6 @@
                 ]
               },
               {
-                "id": "ES6PossiblyAsyncFunction",
-                "shortDescription": {
-                  "text": "'await' in non-async function"
-                },
-                "fullDescription": {
-                  "text": "Reports a usage of 'await' in a function that was possibly intended to be async but is actually missing the 'async' modifier. Although 'await' can be used as an identifier, it is likely that it was intended to be used as an operator, so the containing function should be made 'async'.",
-                  "markdown": "Reports a usage of `await` in a function that was possibly intended to be async but is actually missing the `async` modifier. Although `await` can be used as an identifier, it is likely that it was intended to be used as an operator, so the containing function should be made `async`."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "ES6PossiblyAsyncFunction",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "JavaScript and TypeScript/Async code and promises",
-                      "index": 52,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
                 "id": "TextLabelInSwitchStatementJS",
                 "shortDescription": {
                   "text": "Text label in 'switch' statement"
@@ -7409,6 +3392,39 @@
                     "target": {
                       "id": "JavaScript and TypeScript/Switch statement issues",
                       "index": 50,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ES6PossiblyAsyncFunction",
+                "shortDescription": {
+                  "text": "'await' in non-async function"
+                },
+                "fullDescription": {
+                  "text": "Reports a usage of 'await' in a function that was possibly intended to be async but is actually missing the 'async' modifier. Although 'await' can be used as an identifier, it is likely that it was intended to be used as an operator, so the containing function should be made 'async'.",
+                  "markdown": "Reports a usage of `await` in a function that was possibly intended to be async but is actually missing the `async` modifier. Although `await` can be used as an identifier, it is likely that it was intended to be used as an operator, so the containing function should be made `async`."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "ES6PossiblyAsyncFunction",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JavaScript and TypeScript/Async code and promises",
+                      "index": 52,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -8497,7 +4513,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -8629,7 +4645,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -8794,7 +4810,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -8827,40 +4843,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "JSIncompatibleTypesComparison",
-                "shortDescription": {
-                  "text": "Comparison of expressions having incompatible types"
-                },
-                "fullDescription": {
-                  "text": "Reports a comparison with operands of incompatible types or an operand with a type without possible common values.",
-                  "markdown": "Reports a comparison with operands of incompatible types or an operand with a type without possible common values."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "note",
-                  "parameters": {
-                    "suppressToolId": "JSIncompatibleTypesComparison",
-                    "ideaSeverity": "WEAK WARNING",
-                    "qodanaSeverity": "Moderate"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "JavaScript and TypeScript/Probable bugs",
-                      "index": 16,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -8894,6 +4877,39 @@
                     "target": {
                       "id": "JavaScript and TypeScript/General",
                       "index": 11,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "JSIncompatibleTypesComparison",
+                "shortDescription": {
+                  "text": "Comparison of expressions having incompatible types"
+                },
+                "fullDescription": {
+                  "text": "Reports a comparison with operands of incompatible types or an operand with a type without possible common values.",
+                  "markdown": "Reports a comparison with operands of incompatible types or an operand with a type without possible common values."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "JSIncompatibleTypesComparison",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JavaScript and TypeScript/Probable bugs",
+                      "index": 16,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -9091,7 +5107,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -10147,7 +6163,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -10213,7 +6229,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -10291,39 +6307,6 @@
                 ]
               },
               {
-                "id": "ConstantOnLHSOfComparisonJS",
-                "shortDescription": {
-                  "text": "Constant on left side of comparison"
-                },
-                "fullDescription": {
-                  "text": "Reports a comparison operation with a constant value in the left-hand side. According to coding conventions, constants should be in the right-hand side of comparisons.",
-                  "markdown": "Reports a comparison operation with a constant value in the left-hand side. According to coding conventions, constants should be in the right-hand side of comparisons."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "ConstantOnLefSideOfComparisonJS",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "JavaScript and TypeScript/Code style issues",
-                      "index": 10,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
                 "id": "JSCheckFunctionSignatures",
                 "shortDescription": {
                   "text": "Signature mismatch"
@@ -10346,6 +6329,39 @@
                     "target": {
                       "id": "JavaScript and TypeScript/General",
                       "index": 11,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "ConstantOnLHSOfComparisonJS",
+                "shortDescription": {
+                  "text": "Constant on left side of comparison"
+                },
+                "fullDescription": {
+                  "text": "Reports a comparison operation with a constant value in the left-hand side. According to coding conventions, constants should be in the right-hand side of comparisons.",
+                  "markdown": "Reports a comparison operation with a constant value in the left-hand side. According to coding conventions, constants should be in the right-hand side of comparisons."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "ConstantOnLefSideOfComparisonJS",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JavaScript and TypeScript/Code style issues",
+                      "index": 10,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -10543,7 +6559,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -10786,39 +6802,6 @@
                 ]
               },
               {
-                "id": "IfStatementWithIdenticalBranchesJS",
-                "shortDescription": {
-                  "text": "'if' statement with identical branches"
-                },
-                "fullDescription": {
-                  "text": "Reports an 'if' statement with identical 'then' and 'else' branches. Such statements are almost certainly an error.",
-                  "markdown": "Reports an `if` statement with identical `then` and `else` branches. Such statements are almost certainly an error."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "IfStatementWithIdenticalBranchesJS",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
                 "id": "PlatformDetectionJS",
                 "shortDescription": {
                   "text": "Inaccurate platform detection"
@@ -10841,6 +6824,39 @@
                     "target": {
                       "id": "JavaScript and TypeScript/DOM issues",
                       "index": 51,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "IfStatementWithIdenticalBranchesJS",
+                "shortDescription": {
+                  "text": "'if' statement with identical branches"
+                },
+                "fullDescription": {
+                  "text": "Reports an 'if' statement with identical 'then' and 'else' branches. Such statements are almost certainly an error.",
+                  "markdown": "Reports an `if` statement with identical `then` and `else` branches. Such statements are almost certainly an error."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "IfStatementWithIdenticalBranchesJS",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JavaScript and TypeScript/Control flow issues",
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -11083,6 +7099,39 @@
                 ]
               },
               {
+                "id": "TrivialConditionalJS",
+                "shortDescription": {
+                  "text": "Redundant conditional expression"
+                },
+                "fullDescription": {
+                  "text": "Reports a conditional expression of the form 'condition ? true : false\ncondition ? false : true' These expressions may be safely converted to 'condition\n!condition'",
+                  "markdown": "Reports a conditional expression of the form\n\n\n    condition ? true : false\n    condition ? false : true\n\n\nThese expressions may be safely converted to\n\n\n    condition\n    !condition\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RedundantConditionalExpressionJS",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JavaScript and TypeScript/Control flow issues",
+                      "index": 1,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
                 "id": "TypeScriptDuplicateUnionOrIntersectionType",
                 "shortDescription": {
                   "text": "Duplicate union or intersection type component"
@@ -11116,19 +7165,19 @@
                 ]
               },
               {
-                "id": "TrivialConditionalJS",
+                "id": "InnerHTMLJS",
                 "shortDescription": {
-                  "text": "Redundant conditional expression"
+                  "text": "Use of 'innerHTML' property"
                 },
                 "fullDescription": {
-                  "text": "Reports a conditional expression of the form 'condition ? true : false\ncondition ? false : true' These expressions may be safely converted to 'condition\n!condition'",
-                  "markdown": "Reports a conditional expression of the form\n\n\n    condition ? true : false\n    condition ? false : true\n\n\nThese expressions may be safely converted to\n\n\n    condition\n    !condition\n"
+                  "text": "Reports a JavaScript access to DOM nodes as text using the 'innerHTML' property. Most usages of 'innerHTML' are performed better with explicit DOM calls, such as 'getElementByID()' and 'createElement()'. Additionally, 'innerHTML' will not work with XML DOMs, including DOMs for XHTML if viewed as XML. This can lead to difficulties in diagnosing bugs.",
+                  "markdown": "Reports a JavaScript access to DOM nodes as text using the `innerHTML` property. Most usages of `innerHTML` are performed better with explicit DOM calls, such as `getElementByID()` and `createElement()`. Additionally, `innerHTML` will not work with XML DOMs, including DOMs for XHTML if viewed as XML. This can lead to difficulties in diagnosing bugs."
                 },
                 "defaultConfiguration": {
                   "enabled": false,
                   "level": "warning",
                   "parameters": {
-                    "suppressToolId": "RedundantConditionalExpressionJS",
+                    "suppressToolId": "InnerHTMLJS",
                     "ideaSeverity": "WARNING",
                     "qodanaSeverity": "High"
                   }
@@ -11136,8 +7185,8 @@
                 "relationships": [
                   {
                     "target": {
-                      "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "id": "JavaScript and TypeScript/DOM issues",
+                      "index": 51,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -11171,39 +7220,6 @@
                     "target": {
                       "id": "JavaScript and TypeScript/Switch statement issues",
                       "index": 50,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "InnerHTMLJS",
-                "shortDescription": {
-                  "text": "Use of 'innerHTML' property"
-                },
-                "fullDescription": {
-                  "text": "Reports a JavaScript access to DOM nodes as text using the 'innerHTML' property. Most usages of 'innerHTML' are performed better with explicit DOM calls, such as 'getElementByID()' and 'createElement()'. Additionally, 'innerHTML' will not work with XML DOMs, including DOMs for XHTML if viewed as XML. This can lead to difficulties in diagnosing bugs.",
-                  "markdown": "Reports a JavaScript access to DOM nodes as text using the `innerHTML` property. Most usages of `innerHTML` are performed better with explicit DOM calls, such as `getElementByID()` and `createElement()`. Additionally, `innerHTML` will not work with XML DOMs, including DOMs for XHTML if viewed as XML. This can lead to difficulties in diagnosing bugs."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "InnerHTMLJS",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "JavaScript and TypeScript/DOM issues",
-                      "index": 51,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -11401,7 +7417,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -11434,7 +7450,7 @@
                   {
                     "target": {
                       "id": "JavaScript and TypeScript/Control flow issues",
-                      "index": 3,
+                      "index": 1,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -11545,39 +7561,6 @@
                 ]
               },
               {
-                "id": "ReturnFromFinallyBlockJS",
-                "shortDescription": {
-                  "text": "'return' inside 'finally' block"
-                },
-                "fullDescription": {
-                  "text": "Reports a 'return' statement inside a 'finally' block. Such 'return' statements may mask exceptions thrown, and complicate debugging.",
-                  "markdown": "Reports a `return` statement inside a `finally` block. Such `return` statements may mask exceptions thrown, and complicate debugging."
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "ReturnInsideFinallyBlockJS",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "JavaScript and TypeScript/Try statement issues",
-                      "index": 32,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
                 "id": "JSUnusedLocalSymbols",
                 "shortDescription": {
                   "text": "Unused local symbol"
@@ -11611,6 +7594,39 @@
                 ]
               },
               {
+                "id": "ReturnFromFinallyBlockJS",
+                "shortDescription": {
+                  "text": "'return' inside 'finally' block"
+                },
+                "fullDescription": {
+                  "text": "Reports a 'return' statement inside a 'finally' block. Such 'return' statements may mask exceptions thrown, and complicate debugging.",
+                  "markdown": "Reports a `return` statement inside a `finally` block. Such `return` statements may mask exceptions thrown, and complicate debugging."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "ReturnInsideFinallyBlockJS",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "JavaScript and TypeScript/Try statement issues",
+                      "index": 32,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
                 "id": "JSValidateTypes",
                 "shortDescription": {
                   "text": "Type mismatch"
@@ -11633,6 +7649,3990 @@
                     "target": {
                       "id": "JavaScript and TypeScript/General",
                       "index": 11,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          },
+          {
+            "name": "org.editorconfig.editorconfigjetbrains",
+            "version": "241.17568",
+            "rules": [
+              {
+                "id": "EditorConfigCharClassRedundancy",
+                "shortDescription": {
+                  "text": "Unnecessary character class"
+                },
+                "fullDescription": {
+                  "text": "Reports character classes that consist of a single character. Such classes can be simplified to a character, for example '[a]'→'a'.",
+                  "markdown": "Reports character classes that consist of a single character. Such classes can be simplified to a character, for example `[a]`→`a`."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigCharClassRedundancy",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigRootDeclarationUniqueness",
+                "shortDescription": {
+                  "text": "Extra top-level declaration"
+                },
+                "fullDescription": {
+                  "text": "Reports multiple top-level declarations. There can be only one optional “root=true” top-level declaration in the EditorConfig file. Using multiple top-level declarations is not allowed.",
+                  "markdown": "Reports multiple top-level declarations. There can be only one optional \"root=true\" top-level declaration in the EditorConfig file. Using multiple top-level declarations is not allowed."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigRootDeclarationUniqueness",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigNumerousWildcards",
+                "shortDescription": {
+                  "text": "Too many wildcards"
+                },
+                "fullDescription": {
+                  "text": "Reports sections that contain too many wildcards. Using a lot of wildcards may lead to performance issues.",
+                  "markdown": "Reports sections that contain too many wildcards. Using a lot of wildcards may lead to performance issues."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigNumerousWildcards",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigPartialOverride",
+                "shortDescription": {
+                  "text": "Overlapping sections"
+                },
+                "fullDescription": {
+                  "text": "Reports subsets of files specified in the current section that overlap with other subsets in other sections. For example: '[{foo,bar}]' and '[{foo,bas}]' both contain “foo”.",
+                  "markdown": "Reports subsets of files specified in the current section that overlap with other subsets in other sections. For example: `[{foo,bar}]` and `[{foo,bas}]` both contain \"foo\"."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigPartialOverride",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigEmptySection",
+                "shortDescription": {
+                  "text": "Empty section"
+                },
+                "fullDescription": {
+                  "text": "Reports sections that do not contain any EditorConfig properties.",
+                  "markdown": "Reports sections that do not contain any EditorConfig properties."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigEmptySection",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigShadowingOption",
+                "shortDescription": {
+                  "text": "Overriding property"
+                },
+                "fullDescription": {
+                  "text": "Reports properties that override the same properties defined earlier in the file. For example: '[*.java]\nindent_size=4\n[{*.java,*.js}]\nindent_size=2' The second section includes the same files as '[*.java]' but also sets indent_size to value 2. Thus the first declaration 'indent_size=4'will be ignored.",
+                  "markdown": "Reports properties that override the same properties defined earlier in the file.\n\nFor example:\n\n\n    [*.java]\n    indent_size=4\n    [{*.java,*.js}]\n    indent_size=2\n\nThe second section includes the same files as `[*.java]` but also sets indent_size to value 2. Thus the first declaration `indent_size=4`will be ignored."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigShadowingOption",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigListAcceptability",
+                "shortDescription": {
+                  "text": "Unexpected value list"
+                },
+                "fullDescription": {
+                  "text": "Reports lists of values that are used in properties in which lists are not supported. In this case, only a single value can be specified.",
+                  "markdown": "Reports lists of values that are used in properties in which lists are not supported. In this case, only a single value can be specified."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigListAcceptability",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigKeyCorrectness",
+                "shortDescription": {
+                  "text": "Unknown property"
+                },
+                "fullDescription": {
+                  "text": "Reports properties that are not supported by the IDE. Note: some “ij” domain properties may require specific language plugins.",
+                  "markdown": "Reports properties that are not supported by the IDE. Note: some \"ij\" domain properties may require specific language plugins."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigKeyCorrectness",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigPatternEnumerationRedundancy",
+                "shortDescription": {
+                  "text": "Unnecessary braces"
+                },
+                "fullDescription": {
+                  "text": "Reports pattern lists that are either empty '{}' or contain just one pattern, for example '{foo}' in contrast to a list containing multiple patterns, for example '{foo,bar}'. In this case braces are handled as a part of the name. For example, the pattern '*.{a}' will match the file 'my.{a}' but not 'my.a'.",
+                  "markdown": "Reports pattern lists that are either empty `{}` or contain just one pattern, for example `{foo}` in contrast to a list containing multiple patterns, for example `{foo,bar}`. In this case braces are handled as a part of the name. For example, the pattern `*.{a}` will match the file `my.{a}` but not `my.a`."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigPatternEnumerationRedundancy",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigEncoding",
+                "shortDescription": {
+                  "text": "File encoding doesn't match EditorConfig charset"
+                },
+                "fullDescription": {
+                  "text": "Checks that current file encoding matches the encoding defined in \"charset\" property of .editorconfig file.",
+                  "markdown": "Checks that current file encoding matches the encoding defined in \"charset\" property of .editorconfig file."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigEncoding",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigRootDeclarationCorrectness",
+                "shortDescription": {
+                  "text": "Unexpected top-level declaration"
+                },
+                "fullDescription": {
+                  "text": "Reports unexpected top-level declarations. Top-level declarations other than “root=true” are not allowed in the EditorConfig file.",
+                  "markdown": "Reports unexpected top-level declarations. Top-level declarations other than \"root=true\" are not allowed in the EditorConfig file."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigRootDeclarationCorrectness",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigReferenceCorrectness",
+                "shortDescription": {
+                  "text": "Invalid reference"
+                },
+                "fullDescription": {
+                  "text": "Reports identifiers that are either unknown or have a wrong type.",
+                  "markdown": "Reports identifiers that are either unknown or have a wrong type."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigReferenceCorrectness",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigPairAcceptability",
+                "shortDescription": {
+                  "text": "Unexpected key-value pair"
+                },
+                "fullDescription": {
+                  "text": "Reports key-value pairs that are not allowed in the current context.",
+                  "markdown": "Reports key-value pairs that are not allowed in the current context."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigPairAcceptability",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigPatternRedundancy",
+                "shortDescription": {
+                  "text": "Duplicate or redundant pattern"
+                },
+                "fullDescription": {
+                  "text": "Reports file patterns that are redundant as there already are other patterns that define the same scope of files or even a broader one. For example, in '[{*.java,*}]' the first '*.java' pattern defines a narrower scope compared to '*'. That is why it is redundant and can be removed.",
+                  "markdown": "Reports file patterns that are redundant as there already are other patterns that define the same scope of files or even a broader one. For example, in `[{*.java,*}]` the first `*.java` pattern defines a narrower scope compared to `*`. That is why it is redundant and can be removed."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigPatternRedundancy",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigNoMatchingFiles",
+                "shortDescription": {
+                  "text": "No matching files"
+                },
+                "fullDescription": {
+                  "text": "Reports sections with wildcard patterns that do not match any files under the directory in which the '.editorconfig' file is located.",
+                  "markdown": "Reports sections with wildcard patterns that do not match any files under the directory in which the `.editorconfig` file is located."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigNoMatchingFiles",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigDeprecatedDescriptor",
+                "shortDescription": {
+                  "text": "Deprecated property"
+                },
+                "fullDescription": {
+                  "text": "Reports EditorConfig properties that are no longer supported.",
+                  "markdown": "Reports EditorConfig properties that are no longer supported."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigDeprecatedDescriptor",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigWildcardRedundancy",
+                "shortDescription": {
+                  "text": "Redundant wildcard"
+                },
+                "fullDescription": {
+                  "text": "Reports wildcards that become redundant when the “**” wildcard is used in the same section. The “**” wildcard defines a broader set of files than any other wildcard. That is why, any other wildcard used in the same section has no affect and can be removed.",
+                  "markdown": "Reports wildcards that become redundant when the \"\\*\\*\" wildcard is used in the same section.\n\n\nThe \"\\*\\*\" wildcard defines a broader set of files than any other wildcard.\nThat is why, any other wildcard used in the same section has no affect and can be removed."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigWildcardRedundancy",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigHeaderUniqueness",
+                "shortDescription": {
+                  "text": "EditorConfig section is not unique"
+                },
+                "fullDescription": {
+                  "text": "Reports sections that define the same file pattern as other sections.",
+                  "markdown": "Reports sections that define the same file pattern as other sections."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigHeaderUniqueness",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigShadowedOption",
+                "shortDescription": {
+                  "text": "Overridden property"
+                },
+                "fullDescription": {
+                  "text": "Reports properties that are already defined in other sections. For example: '[*.java]\nindent_size=4\n[{*.java,*.js}]\nindent_size=2' The second section includes all '*.java' files too but it also redefines indent_size. As a result the value 2 will be used for files matching '*.java'.",
+                  "markdown": "Reports properties that are already defined in other sections.\n\nFor example:\n\n\n    [*.java]\n    indent_size=4\n    [{*.java,*.js}]\n    indent_size=2\n\nThe second section includes all `*.java` files too but it also redefines indent_size. As a result the value 2 will be used for files matching `*.java`."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigShadowedOption",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigEmptyHeader",
+                "shortDescription": {
+                  "text": "Empty header"
+                },
+                "fullDescription": {
+                  "text": "Reports sections with an empty header. Section header must contain file path globs in the format similar to one supported by 'gitignore'.",
+                  "markdown": "Reports sections with an empty header. Section header must contain file path globs in the format similar to one supported by `gitignore`."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigEmptyHeader",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigValueCorrectness",
+                "shortDescription": {
+                  "text": "Invalid property value"
+                },
+                "fullDescription": {
+                  "text": "Reports property values that do not meet value restrictions. For example, some properties may be only “true” or “false”, others contain only integer numbers etc. If a value has a limited set of variants, use code completion to see all of them.",
+                  "markdown": "Reports property values that do not meet value restrictions. For example, some properties may be only \"true\" or \"false\", others contain only integer numbers etc. If a value has a limited set of variants, use code completion to see all of them."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigValueCorrectness",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigVerifyByCore",
+                "shortDescription": {
+                  "text": "Invalid .editorconfig file"
+                },
+                "fullDescription": {
+                  "text": "Verifies the whole file using the backing EditorConfig core library and reports any failures. Any such failure would prevent EditorConfig properties from being correctly applied.",
+                  "markdown": "Verifies the whole file using the backing EditorConfig core library and reports any failures. Any such failure would prevent EditorConfig properties from being correctly applied."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigVerifyByCore",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigValueUniqueness",
+                "shortDescription": {
+                  "text": "Non-unique list value"
+                },
+                "fullDescription": {
+                  "text": "Reports duplicates in lists of values.",
+                  "markdown": "Reports duplicates in lists of values."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigValueUniqueness",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigMissingRequiredDeclaration",
+                "shortDescription": {
+                  "text": "Required declarations are missing"
+                },
+                "fullDescription": {
+                  "text": "Reports properties that miss the required declarations. Refer to the documentation for more information.",
+                  "markdown": "Reports properties that miss the required declarations. Refer to the documentation for more information."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigMissingRequiredDeclaration",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigCharClassLetterRedundancy",
+                "shortDescription": {
+                  "text": "Duplicate character class letter"
+                },
+                "fullDescription": {
+                  "text": "Reports wildcard patterns in the EditorConfig section that contain a duplicate character in the character class, for example '[aa]'.",
+                  "markdown": "Reports wildcard patterns in the EditorConfig section that contain a duplicate character in the character class, for example `[aa]`."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigCharClassLetterRedundancy",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigSpaceInHeader",
+                "shortDescription": {
+                  "text": "Space in file pattern"
+                },
+                "fullDescription": {
+                  "text": "Reports space characters in wildcard patterns that affect pattern matching. If these characters are not intentional, they should be removed.",
+                  "markdown": "Reports space characters in wildcard patterns that affect pattern matching. If these characters are not intentional, they should be removed."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigSpaceInHeader",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigOptionRedundancy",
+                "shortDescription": {
+                  "text": "Redundant property"
+                },
+                "fullDescription": {
+                  "text": "Reports properties that are redundant when another applicable section already contains the same property and value. For example: '[*]\nindent_size=4\n[*.java]\nindent_size=4' are both applicable to '*.java' files and define the same 'indent_size' value.",
+                  "markdown": "Reports properties that are redundant when another applicable section already contains the same property and value.\n\n\nFor example:\n\n\n    [*]\n    indent_size=4\n    [*.java]\n    indent_size=4\n\nare both applicable to `*.java` files and define the same `indent_size` value."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigOptionRedundancy",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigUnusedDeclaration",
+                "shortDescription": {
+                  "text": "Unused declaration"
+                },
+                "fullDescription": {
+                  "text": "Reports unused declarations. Such declarations can be removed.",
+                  "markdown": "Reports unused declarations. Such declarations can be removed."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigUnusedDeclaration",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "EditorConfigUnexpectedComma",
+                "shortDescription": {
+                  "text": "Unexpected comma"
+                },
+                "fullDescription": {
+                  "text": "Reports commas that cannot be used in the current context. Commas are allowed only as separators for values in lists.",
+                  "markdown": "Reports commas that cannot be used in the current context. Commas are allowed only as separators for values in lists."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "error",
+                  "parameters": {
+                    "suppressToolId": "EditorConfigUnexpectedComma",
+                    "ideaSeverity": "ERROR",
+                    "qodanaSeverity": "Critical"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "EditorConfig",
+                      "index": 2,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "language": "en-US",
+            "contents": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "isComprehensive": false
+          },
+          {
+            "name": "Pythonid",
+            "version": "241.17568",
+            "rules": [
+              {
+                "id": "PyPandasSeriesToListInspection",
+                "shortDescription": {
+                  "text": "Method Series.to_list() is recommended"
+                },
+                "fullDescription": {
+                  "text": "Reports redundant 'list' in 'list(Series.values)' statement for pandas and polars libraries. Such 'Series' values extraction can be replaced with the 'to_list()' function call. Example: list(df['column'].values)\n When the quick-fix is applied, the code changes to: df['column'].to_list()",
+                  "markdown": "Reports redundant `list` in `list(Series.values)` statement for pandas and polars libraries.\nSuch `Series` values extraction can be replaced with the `to_list()` function call.\n\n**Example:**\n\n```\nlist(df['column'].values)\n```\n\nWhen the quick-fix is applied, the code changes to:\n\n```\ndf['column'].to_list()\n```"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyPackages",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PySetFunctionToLiteralInspection",
+                "shortDescription": {
+                  "text": "Function call can be replaced with set literal"
+                },
+                "fullDescription": {
+                  "text": "Reports calls to the 'set' function that can be replaced with the 'set' literal. Example: 'def do_mult(a, b):\n    c = a * b\n    return set([c, a, b])' When the quick-fix is applied, the code changes to: 'def do_mult(a, b):\n    c = a * b\n    return {c, a, b}'",
+                  "markdown": "Reports calls to the `set` function that can be replaced with\nthe `set` literal.\n\n**Example:**\n\n\n    def do_mult(a, b):\n        c = a * b\n        return set([c, a, b])\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    def do_mult(a, b):\n        c = a * b\n        return {c, a, b}\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PySetFunctionToLiteral",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyOverridesInspection",
+                "shortDescription": {
+                  "text": "Invalid usages of @override decorator"
+                },
+                "fullDescription": {
+                  "text": "Reports when a method decorated with @override doesn't have a matching method in its ancestor classes Example: 'from typing import override\n\nclass Parent:\n    def foo(self) -> int:\n        return 1\n\n    def bar(self, x: str) -> str:\n        return x\n\nclass Child(Parent):\n    @override\n    def foo(self) -> int:\n        return 2\n\n    @override # Missing super method for override function\n    def baz(self) -> int:\n        return 1'",
+                  "markdown": "Reports when a method decorated with @override doesn't have a matching method in its ancestor classes\n\n**Example:**\n\n\n    from typing import override\n\n    class Parent:\n        def foo(self) -> int:\n            return 1\n\n        def bar(self, x: str) -> str:\n            return x\n\n    class Child(Parent):\n        @override\n        def foo(self) -> int:\n            return 2\n\n        @override # Missing super method for override function\n        def baz(self) -> int:\n            return 1\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyOverrides",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyInitNewSignatureInspection",
+                "shortDescription": {
+                  "text": "Incompatible signatures of __new__ and __init__"
+                },
+                "fullDescription": {
+                  "text": "Reports incompatible signatures of the '__new__' and '__init__' methods. Example: 'class MyClass(object):\n    def __new__(cls, arg1):\n        return super().__new__(cls)\n\n    def __init__(self):\n        pass' If the '__new__' and '__init__' have different arguments, then the 'MyClass' cannot be instantiated. As a fix, the IDE offers to apply the Change Signature refactoring.",
+                  "markdown": "Reports incompatible signatures of the `__new__` and `__init__` methods.\n\n**Example:**\n\n\n    class MyClass(object):\n        def __new__(cls, arg1):\n            return super().__new__(cls)\n\n        def __init__(self):\n            pass\n\nIf the `__new__` and `__init__` have different arguments, then the `MyClass`\ncannot be instantiated.\n\nAs a fix, the IDE offers to apply the Change Signature refactoring."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyInitNewSignature",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyMissingConstructorInspection",
+                "shortDescription": {
+                  "text": "Missed call to '__init__' of the super class"
+                },
+                "fullDescription": {
+                  "text": "Reports cases when a call to the 'super' constructor in a class is missed. Example: 'class Fruit:\n    def __init__(self):\n        pass\n\n\nclass Pear(Fruit):\n    def __init__(self):\n        pass' The 'Pear' class should have a 'super' call in the '__init__' method. When the quick-fix is applied, the code changes to: 'class Fruit:\n    def __init__(self):\n        pass\n\n\nclass Pear(Fruit):\n    def __init__(self):\n        super().__init__()'",
+                  "markdown": "Reports cases when a call to the `super` constructor in a class is missed.\n\n**Example:**\n\n\n    class Fruit:\n        def __init__(self):\n            pass\n\n\n    class Pear(Fruit):\n        def __init__(self):\n            pass\n\nThe `Pear` class should have a `super` call in the `__init__`\nmethod.\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    class Fruit:\n        def __init__(self):\n            pass\n\n\n    class Pear(Fruit):\n        def __init__(self):\n            super().__init__()\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyMissingConstructor",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PySimplifyBooleanCheckInspection",
+                "shortDescription": {
+                  "text": "Redundant boolean variable check"
+                },
+                "fullDescription": {
+                  "text": "Reports equality comparison with a boolean literal. Example: 'def func(s):\n    if s.isdigit() == True:\n        return int(s)' With the quick-fix applied, the code fragment will be simplified to: 'def func(s):\n    if s.isdigit():\n        return int(s)'",
+                  "markdown": "Reports equality comparison with a boolean literal.\n\n**Example:**\n\n\n    def func(s):\n        if s.isdigit() == True:\n            return int(s)\n\nWith the quick-fix applied, the code fragment will be simplified to:\n\n\n    def func(s):\n        if s.isdigit():\n            return int(s)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PySimplifyBooleanCheck",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyCallingNonCallableInspection",
+                "shortDescription": {
+                  "text": "Attempt to call a non-callable object"
+                },
+                "fullDescription": {
+                  "text": "Reports a problem when you are trying to call objects that are not callable, like, for example, properties: Example: 'class Record:\n    @property\n    def as_json(self):\n\njson = Record().as_json()'",
+                  "markdown": "Reports a problem when you are trying\nto call objects that are not callable, like, for example, properties:\n\n**Example:**\n\n\n    class Record:\n        @property\n        def as_json(self):\n\n    json = Record().as_json()\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyCallingNonCallable",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyUnreachableCodeInspection",
+                "shortDescription": {
+                  "text": "Unreachable code"
+                },
+                "fullDescription": {
+                  "text": "Reports code fragments that cannot be normally reached. Example: 'if True:\n    print('Yes')\nelse:\n    print('No')' As a fix, you might want to check and modify the algorithm to ensure it implements the expected logic.",
+                  "markdown": "Reports code fragments that cannot be normally reached.\n\n**Example:**\n\n\n    if True:\n        print('Yes')\n    else:\n        print('No')\n\nAs a fix, you might want to check and modify the algorithm to ensure it implements\nthe expected logic."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyUnreachableCode",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyChainedComparisonsInspection",
+                "shortDescription": {
+                  "text": "Too complex chained comparisons"
+                },
+                "fullDescription": {
+                  "text": "Reports chained comparisons that can be simplified. Example: 'def do_comparison(x):\n      xmin = 10\n      xmax = 100\n      if x >= xmin and x <= xmax:\n          pass' The IDE offers to simplify 'if x >= xmin and x <= xmax'. When the quick-fix is applied, the code changes to: 'def do_comparison(x):\n      xmin = 10\n      xmax = 100\n      if xmin <= x <= xmax:\n          pass'",
+                  "markdown": "Reports chained comparisons that can be simplified.\n\n**Example:**\n\n\n      def do_comparison(x):\n          xmin = 10\n          xmax = 100\n          if x >= xmin and x <= xmax:\n              pass\n\nThe IDE offers to simplify `if x >= xmin and x <= xmax`.\nWhen the quick-fix is applied, the code changes to:\n\n\n      def do_comparison(x):\n          xmin = 10\n          xmax = 100\n          if xmin <= x <= xmax:\n              pass\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyChainedComparisons",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyCompatibilityInspection",
+                "shortDescription": {
+                  "text": "Code is incompatible with specific Python versions"
+                },
+                "fullDescription": {
+                  "text": "Reports incompatibility with the specified versions of Python. Enable this inspection if you need your code to be compatible with a range of Python versions, for example, if you are building a library. To define the range of the inspected Python versions, select the corresponding checkboxes in the Options section. For more information about the Python versions supported by the IDE, see the web help.",
+                  "markdown": "Reports incompatibility with the specified versions of Python.\nEnable this inspection if you need your code to be compatible with a range of Python versions, for example,\nif you are building a library.\n\nTo define the range of the inspected Python versions, select the corresponding checkboxes in the **Options**\nsection.\n\nFor more information about the Python versions supported by the IDE, see the\n[web help](https://www.jetbrains.com/help/pycharm/python.html#support)."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyCompatibility",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyGlobalUndefinedInspection",
+                "shortDescription": {
+                  "text": "Global variable is not defined at the module level"
+                },
+                "fullDescription": {
+                  "text": "Reports problems when a variable defined through the 'global' statement is not defined in the module scope. Example: 'def foo():\n    global bar\n    print(bar)\n\nfoo()' As a fix, you can move the global variable declaration: 'global bar\n\n\ndef foo():\n    print(bar)'",
+                  "markdown": "Reports problems when a variable defined through the `global`\nstatement is not defined in the module scope.\n\n**Example:**\n\n\n    def foo():\n        global bar\n        print(bar)\n\n    foo()\n\nAs a fix, you can move the global variable declaration:\n\n\n    global bar\n\n\n    def foo():\n        print(bar)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyGlobalUndefined",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "UnsatisfiedRequirementInspection",
+                "shortDescription": {
+                  "text": "Requirement is not satisfied"
+                },
+                "fullDescription": {
+                  "text": "Reports packages mentioned in requirements files (for example, 'requirements.txt', or 'dependencies' section in 'pyproject.toml' files) but not installed, or imported but not mentioned in requirements files.",
+                  "markdown": "Reports packages mentioned in requirements files (for example, `requirements.txt`, or `dependencies` section in `pyproject.toml` files) but not installed,\nor imported but not mentioned in requirements files."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "UnsatisfiedRequirement",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Requirements",
+                      "index": 37,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyProtocolInspection",
+                "shortDescription": {
+                  "text": "Invalid protocol definitions and usages"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid definitions and usages of protocols introduced in PEP-544. Example: 'from typing import Protocol\n\n\nclass MyProtocol(Protocol):\n    def method(self, p: int) -> str:\n        pass\n\n\nclass MyClass(MyProtocol):\n    def method(self, p: str) -> int: # Type of 'method' is not compatible with 'MyProtocol'\n        pass\n\n\nclass MyAnotherProtocol(MyClass, Protocol): # All bases of a protocol must be protocols\n    pass'",
+                  "markdown": "Reports invalid definitions and usages of protocols introduced in\n[PEP-544](https://www.python.org/dev/peps/pep-0544/).\n\n**Example:**\n\n\n    from typing import Protocol\n\n\n    class MyProtocol(Protocol):\n        def method(self, p: int) -> str:\n            pass\n\n\n    class MyClass(MyProtocol):\n        def method(self, p: str) -> int: # Type of 'method' is not compatible with 'MyProtocol'\n            pass\n\n\n    class MyAnotherProtocol(MyClass, Protocol): # All bases of a protocol must be protocols\n        pass\n\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyProtocol",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyTypeHintsInspection",
+                "shortDescription": {
+                  "text": "Invalid type hints definitions and usages"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid usages of type hints. Example: 'from typing import TypeVar\n\nT0 = TypeVar('T1') # Argument of 'TypeVar' must be 'T0'\n\n\ndef b(p: int) -> int:  # Type specified both in a comment and annotation\n    # type: (int) -> int\n    pass\n\n\ndef c(p1, p2): # Type signature has too many arguments\n    # type: (int) -> int\n    pass' Available quick-fixes offer various actions. You can rename, remove, or move problematic elements. You can also manually modify type declarations to ensure no warning is shown.",
+                  "markdown": "Reports invalid usages of type hints.\n\n**Example:**\n\n\n    from typing import TypeVar\n\n    T0 = TypeVar('T1') # Argument of 'TypeVar' must be 'T0'\n\n\n    def b(p: int) -> int:  # Type specified both in a comment and annotation\n        # type: (int) -> int\n        pass\n\n\n    def c(p1, p2): # Type signature has too many arguments\n        # type: (int) -> int\n        pass\n\nAvailable quick-fixes offer various actions. You can rename, remove, or move problematic elements. You can also manually modify type declarations to ensure no warning is shown."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyTypeHints",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyMethodMayBeStaticInspection",
+                "shortDescription": {
+                  "text": "Method is not declared static"
+                },
+                "fullDescription": {
+                  "text": "Reports any methods that do not require a class instance creation and can be made static. Example: 'class MyClass(object):\n    def my_method(self, x):\n        print(x)' If a Make function from method quick-fix is applied, the code changes to: 'def my_method(x):\n    print(x)\n\n\nclass MyClass(object):\n    pass' If you select the Make method static quick-fix, the '@staticmethod' decorator is added: 'class MyClass(object):\n    @staticmethod\n    def my_method(x):\n        print(x)'",
+                  "markdown": "Reports any methods that do not require a class instance creation and can be\nmade static.\n\n**Example:**\n\n\n    class MyClass(object):\n        def my_method(self, x):\n            print(x)\n\nIf a **Make function from method** quick-fix is applied, the code changes to:\n\n\n    def my_method(x):\n        print(x)\n\n\n    class MyClass(object):\n        pass\n\nIf you select the **Make method static** quick-fix, the `@staticmethod` decorator is added:\n\n\n    class MyClass(object):\n        @staticmethod\n        def my_method(x):\n            print(x)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyMethodMayBeStatic",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CythonUsageBeforeDeclarationInspection",
+                "shortDescription": {
+                  "text": "Cython variable is used before its declaration"
+                },
+                "fullDescription": {
+                  "text": "Reports Cython variables being referenced before declaration. Example: 'cdef int c_x\n\nprint(c_x, c_y)  # Variable 'c_y' is used before its declaration\n\ncdef int c_y = 0'",
+                  "markdown": "Reports Cython variables being referenced before declaration.\n\n**Example:**\n\n\n    cdef int c_x\n\n    print(c_x, c_y)  # Variable 'c_y' is used before its declaration\n\n    cdef int c_y = 0\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CythonUsageBeforeDeclaration",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyDictCreationInspection",
+                "shortDescription": {
+                  "text": "Dictionary creation can be rewritten by dictionary literal"
+                },
+                "fullDescription": {
+                  "text": "Reports situations when you can rewrite dictionary creation by using a dictionary literal. This approach brings performance improvements. Example: 'dic = {}\ndic['var'] = 1' When the quick-fix is applied, the code changes to: 'dic = {'var': 1}'",
+                  "markdown": "Reports situations when you can rewrite dictionary creation\nby using a dictionary literal.\n\nThis approach brings performance improvements.\n\n**Example:**\n\n\n    dic = {}\n    dic['var'] = 1\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    dic = {'var': 1}\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyDictCreation",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyStringFormatInspection",
+                "shortDescription": {
+                  "text": "Errors in string formatting operations"
+                },
+                "fullDescription": {
+                  "text": "Reports errors in string formatting operations. Example 1: '\"Hello {1}\".format(\"people\")' Example 2: 'def bar():\n    return 1\n\n\n\"%s %s\" % bar()' As a fix, you need to rewrite string formatting fragments to adhere to the formatting syntax.",
+                  "markdown": "Reports errors in string formatting operations.\n\n**Example 1:**\n\n\n    \"Hello {1}\".format(\"people\")\n\n**Example 2:**\n\n\n    def bar():\n        return 1\n\n\n    \"%s %s\" % bar()\n\nAs a fix, you need to rewrite string formatting fragments to\nadhere to the [formatting syntax](https://docs.python.org/3/library/string.html#format-string-syntax)."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyStringFormat",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyExceptionInheritInspection",
+                "shortDescription": {
+                  "text": "Exceptions do not inherit from standard 'Exception' class"
+                },
+                "fullDescription": {
+                  "text": "Reports cases when a custom exception class is raised but does not inherit from the builtin Exception class. Example: 'class A:\n    pass\n\n\ndef me_exception():\n    raise A()' The proposed quick-fix changes the code to: 'class A(Exception):\n    pass\n\n\ndef me_exception():\n    raise A()'",
+                  "markdown": "Reports cases when a custom exception class is\nraised but does not inherit from the\n[builtin Exception class](https://docs.python.org/3/library/exceptions.html).\n\n**Example:**\n\n\n    class A:\n        pass\n\n\n    def me_exception():\n        raise A()\n\nThe proposed quick-fix changes the code to:\n\n\n    class A(Exception):\n        pass\n\n\n    def me_exception():\n        raise A()\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyExceptionInherit",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyAssignmentToLoopOrWithParameterInspection",
+                "shortDescription": {
+                  "text": "Assignments to 'for' loop or 'with' statement parameter"
+                },
+                "fullDescription": {
+                  "text": "Reports the cases when you rewrite a loop variable with an inner loop. Example: 'for i in range(5):\n      for i in range(20, 25):\n          print(\"Inner\", i)\n      print(\"Outer\", i)' It also warns you if a variable declared in the 'with' statement is redeclared inside the statement body: 'with open(\"file\") as f:\n      f.read()\n      with open(\"file\") as f:'",
+                  "markdown": "Reports the cases when you rewrite a loop variable with an inner loop.\n\n**Example:**\n\n\n        for i in range(5):\n          for i in range(20, 25):\n              print(\"Inner\", i)\n          print(\"Outer\", i)\n      \nIt also warns you if a variable declared in the `with` statement is redeclared inside the statement body:\n\n\n        with open(\"file\") as f:\n          f.read()\n          with open(\"file\") as f:\n      \n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyAssignmentToLoopOrWithParameter",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PySuperArgumentsInspection",
+                "shortDescription": {
+                  "text": "Wrong arguments to call super"
+                },
+                "fullDescription": {
+                  "text": "Reports cases when any call to 'super(A, B)' does not meet the following requirements: 'B' is an instance of 'A' 'B' a subclass of 'A' Example: 'class Figure:\n    def color(self):\n        pass\n\n\nclass Rectangle(Figure):\n    def color(self):\n        pass\n\n\nclass Square(Figure):\n    def color(self):\n        return super(Rectangle, self).color() # Square is not an instance or subclass of Rectangle' As a fix, you can make the 'Square' an instance of the 'Rectangle' class.",
+                  "markdown": "Reports cases when any call to `super(A, B)` does not meet the\nfollowing requirements:\n\n* `B` is an instance of `A`\n* `B` a subclass of `A`\n\n**Example:**\n\n\n    class Figure:\n        def color(self):\n            pass\n\n\n    class Rectangle(Figure):\n        def color(self):\n            pass\n\n\n    class Square(Figure):\n        def color(self):\n            return super(Rectangle, self).color() # Square is not an instance or subclass of Rectangle\n\nAs a fix, you can make the `Square` an instance of the `Rectangle` class."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PySuperArguments",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyNonAsciiCharInspection",
+                "shortDescription": {
+                  "text": "File contains non-ASCII character"
+                },
+                "fullDescription": {
+                  "text": "Reports cases in Python 2 when a file contains non-ASCII characters and does not have an encoding declaration at the top. Example: 'class A(object):\n# №5\n    def __init__(self):\n        pass' In this example, the IDE reports a non-ASCII symbol in a comment and a lack of encoding declaration. Apply the proposed quick-fix to add a missing encoding declaration: '# coding=utf-8\nclass A(object)\n# №5\n    def __init__(self):\n        pass'",
+                  "markdown": "Reports cases in Python 2 when a file contains non-ASCII characters and does not\nhave an encoding declaration at the top.\n\n**Example:**\n\n\n    class A(object):\n    # №5\n        def __init__(self):\n            pass\n\nIn this example, the IDE reports a non-ASCII symbol in a comment and a lack of encoding\ndeclaration. Apply the proposed quick-fix to add a missing encoding declaration:\n\n\n    # coding=utf-8\n    class A(object)\n    # №5\n        def __init__(self):\n            pass\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyNonAsciiChar",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyOldStyleClassesInspection",
+                "shortDescription": {
+                  "text": "Old-style class contains new-style class features"
+                },
+                "fullDescription": {
+                  "text": "Reports occurrences of new-style class features in old-style classes. The inspection highlights '__slots__', '__getattribute__', and 'super()' inside old-style classes.",
+                  "markdown": "Reports occurrences of\n[new-style class features](https://www.python.org/doc/newstyle/)\nin old-style classes. The inspection highlights\n`__slots__`, `__getattribute__`, and `super()`\ninside old-style classes."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyOldStyleClasses",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyAbstractClassInspection",
+                "shortDescription": {
+                  "text": "Class must implement all abstract methods"
+                },
+                "fullDescription": {
+                  "text": "Reports cases when not all abstract properties or methods are defined in a subclass. Example: 'from abc import abstractmethod, ABC\n\n\nclass Figure(ABC):\n\n    @abstractmethod\n    def do_figure(self):\n        pass\n\n\nclass Triangle(Figure):\n    def do_triangle(self):\n        pass' When the quick-fix is applied, the IDE implements an abstract method for the 'Triangle' class: 'from abc import abstractmethod, ABC\n\n\nclass Figure(ABC):\n\n    @abstractmethod\n    def do_figure(self):\n        pass\n\n\nclass Triangle(Figure):\n    def do_figure(self):\n        pass\n\n    def do_triangle(self):\n        pass'",
+                  "markdown": "Reports cases when not all abstract properties or methods are defined in\na subclass.\n\n**Example:**\n\n\n    from abc import abstractmethod, ABC\n\n\n    class Figure(ABC):\n\n        @abstractmethod\n        def do_figure(self):\n            pass\n\n\n    class Triangle(Figure):\n        def do_triangle(self):\n            pass\n\nWhen the quick-fix is applied, the IDE implements an abstract method for the `Triangle` class:\n\n\n    from abc import abstractmethod, ABC\n\n\n    class Figure(ABC):\n\n        @abstractmethod\n        def do_figure(self):\n            pass\n\n\n    class Triangle(Figure):\n        def do_figure(self):\n            pass\n\n        def do_triangle(self):\n            pass\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyAbstractClass",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyBroadExceptionInspection",
+                "shortDescription": {
+                  "text": "Unclear exception clauses"
+                },
+                "fullDescription": {
+                  "text": "Reports exception clauses that do not provide specific information about the problem. Example: Clauses that do not specify an exception class Clauses that are specified as 'Exception'",
+                  "markdown": "Reports exception clauses that do not provide specific information\nabout the problem.\n\n**Example:**\n\n* Clauses that do not specify an exception class\n* Clauses that are specified as `Exception`"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyBroadException",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyTypeCheckerInspection",
+                "shortDescription": {
+                  "text": "Incorrect type"
+                },
+                "fullDescription": {
+                  "text": "Reports type errors in function call expressions, targets, and return values. In a dynamically typed language, this is possible in a limited number of cases. Types of function parameters can be specified in docstrings or in Python 3 function annotations. Example: 'def foo() -> int:\n    return \"abc\" # Expected int, got str\n\n\na: str\na = foo() # Expected str, got int' With the quick-fix, you can modify the problematic types: 'def foo() -> str:\n    return \"abc\"\n\n\na: str\na = foo()'",
+                  "markdown": "Reports type errors in function call expressions, targets, and return values. In a dynamically typed language, this is possible in a limited number of cases.\n\nTypes of function parameters can be specified in\ndocstrings or in Python 3 function annotations.\n\n**Example:**\n\n\n    def foo() -> int:\n        return \"abc\" # Expected int, got str\n\n\n    a: str\n    a = foo() # Expected str, got int\n\nWith the quick-fix, you can modify the problematic types:\n\n\n    def foo() -> str:\n        return \"abc\"\n\n\n    a: str\n    a = foo()\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyTypeChecker",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyByteLiteralInspection",
+                "shortDescription": {
+                  "text": "A byte literal contains a non-ASCII character"
+                },
+                "fullDescription": {
+                  "text": "Reports characters in byte literals that are outside ASCII range. Example: 's = b'№5''",
+                  "markdown": "Reports characters in byte literals that are outside ASCII range.\n\n**Example:**\n\n\n      s = b'№5'\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyByteLiteral",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyAugmentAssignmentInspection",
+                "shortDescription": {
+                  "text": "Assignment can be replaced with augmented assignment"
+                },
+                "fullDescription": {
+                  "text": "Reports assignments that can be replaced with augmented assignments. Example: 'a = 23\nb = 3\na = a + b' After the quick-fix is applied, the code changes to: 'a = 23\nb = 3\na += b'",
+                  "markdown": "Reports assignments that can be replaced with augmented assignments.\n\n**Example:**\n\n\n    a = 23\n    b = 3\n    a = a + b\n\nAfter the quick-fix is applied, the code changes to:\n\n\n    a = 23\n    b = 3\n    a += b\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyAugmentAssignment",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyDeprecationInspection",
+                "shortDescription": {
+                  "text": "Deprecated function, class, or module"
+                },
+                "fullDescription": {
+                  "text": "Reports usages of Python functions, or methods that are marked as deprecated and raise the 'DeprecationWarning' or 'PendingDeprecationWarning' warning. Also, this inspection highlights usages of 'abc.abstractstaticmethod', 'abc.abstractproperty', and 'abc.abstractclassmethod' decorators. Example: 'class Foo:\n    @property\n    def bar(self):\n        import warnings\n        warnings.warn(\"this is deprecated\", DeprecationWarning, 2)\n        return 5\n\n\nfoo = Foo()\nprint(foo.bar)'",
+                  "markdown": "Reports usages of Python functions, or methods that are marked as\ndeprecated and raise the `DeprecationWarning` or `PendingDeprecationWarning` warning.\n\nAlso, this inspection highlights usages of `abc.abstractstaticmethod`, `abc.abstractproperty`, and `abc.abstractclassmethod`\ndecorators.\n\n**Example:**\n\n\n    class Foo:\n        @property\n        def bar(self):\n            import warnings\n            warnings.warn(\"this is deprecated\", DeprecationWarning, 2)\n            return 5\n\n\n    foo = Foo()\n    print(foo.bar)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyDeprecation",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyUnnecessaryBackslashInspection",
+                "shortDescription": {
+                  "text": "Unnecessary backslash"
+                },
+                "fullDescription": {
+                  "text": "Reports backslashes in places where line continuation is implicit inside '()', '[]', and '{}'. Example: 'a = ('first', \\\n     'second', 'third')' When the quick-fix is applied, the redundant backslash is deleted.",
+                  "markdown": "Reports backslashes in places where line continuation is implicit inside `()`,\n`[]`, and `{}`.\n\n**Example:**\n\n\n    a = ('first', \\\n         'second', 'third')\n\nWhen the quick-fix is applied, the redundant backslash is deleted."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyUnnecessaryBackslash",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyShadowingNamesInspection",
+                "shortDescription": {
+                  "text": "Shadowing names from outer scopes"
+                },
+                "fullDescription": {
+                  "text": "Reports shadowing names defined in outer scopes. Example: 'def outer(p):\n    def inner(p):\n        pass' As a quick-fix, the IDE offers to remove a parameter or rename it.",
+                  "markdown": "Reports shadowing names defined in outer scopes.\n\n**Example:**\n\n\n    def outer(p):\n        def inner(p):\n            pass\n\nAs a quick-fix, the IDE offers to remove a parameter or rename it."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyShadowingNames",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyFinalInspection",
+                "shortDescription": {
+                  "text": "Invalid usages of final classes, methods, and variables"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid usages of final classes, methods and variables. Example: 'from typing import final\n\n\n@final\nclass A:\n    def a_method(self):\n        pass\n\n\nclass B(A):\n    def a_method(self):\n        pass'",
+                  "markdown": "Reports invalid usages of final classes,\nmethods and variables.\n\n**Example:**\n\n\n    from typing import final\n\n\n    @final\n    class A:\n        def a_method(self):\n            pass\n\n\n    class B(A):\n        def a_method(self):\n            pass\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyFinal",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PySingleQuotedDocstringInspection",
+                "shortDescription": {
+                  "text": "Single quoted docstring"
+                },
+                "fullDescription": {
+                  "text": "Reports docstrings that do not adhere to the triple double-quoted string format. Example: 'def calc(self, balance=0):\n    'param: balance'\n    self.balance = balance' When the quick-fix is applied, the code changes to: 'def calc(self, balance=0):\n    \"\"\"param: balance\"\"\"\n    self.balance = balance'",
+                  "markdown": "Reports docstrings that do not adhere to the triple double-quoted string format.\n\n**Example:**\n\n\n    def calc(self, balance=0):\n        'param: balance'\n        self.balance = balance\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    def calc(self, balance=0):\n        \"\"\"param: balance\"\"\"\n        self.balance = balance\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PySingleQuotedDocstring",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyUnusedLocalInspection",
+                "shortDescription": {
+                  "text": "Unused local symbols"
+                },
+                "fullDescription": {
+                  "text": "Reports local variables, parameters, and functions that are locally defined, but not used name in a function.",
+                  "markdown": "Reports local variables, parameters, and functions that are locally defined, but not used name in a function."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyUnusedLocal",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyReturnFromInitInspection",
+                "shortDescription": {
+                  "text": "__init__ method that returns a value"
+                },
+                "fullDescription": {
+                  "text": "Reports occurrences of 'return' statements with a return value inside '__init__' methods of classes. Example: 'class Sum:\n    def __init__(self, a, b):\n        self.a = a\n        self.b = b\n        self.sum = a + b\n        return self.sum' A constructor should not return any value. The '__init__' method should only initialize the values of instance members for news objects. As a quick-fix, the IDE offers to remove the 'return' statement.",
+                  "markdown": "Reports occurrences of `return` statements with a return value inside\n`__init__` methods of classes.\n\n**Example:**\n\n\n    class Sum:\n        def __init__(self, a, b):\n            self.a = a\n            self.b = b\n            self.sum = a + b\n            return self.sum\n\nA constructor should not return any value. The `__init__` method should\nonly initialize the values of instance members for news objects.\n\nAs a quick-fix, the IDE offers to remove the `return` statement."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyReturnFromInit",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyMissingOrEmptyDocstringInspection",
+                "shortDescription": {
+                  "text": "Missing or empty docstring"
+                },
+                "fullDescription": {
+                  "text": "Reports missing and empty docstrings. Example of a missing docstring 'def demo(a):\n    c = a ** 2' Example of an empty docstring 'def demo(a):\n    \"\"\"\n    \"\"\"\n    c = a ** 2' When the quick-fix is applied, the code fragments change to: 'def demo(a):\n    \"\"\"\n\n    :param a:\n    \"\"\"\n    c = a ** 2' You need to provide some details about the parameter in the generated template.",
+                  "markdown": "Reports missing and empty docstrings.\n\n**Example of a missing docstring**\n\n\n    def demo(a):\n        c = a ** 2\n\n**Example of an empty docstring**\n\n\n    def demo(a):\n        \"\"\"\n        \"\"\"\n        c = a ** 2\n\nWhen the quick-fix is applied, the code fragments change to:\n\n\n    def demo(a):\n        \"\"\"\n\n        :param a:\n        \"\"\"\n        c = a ** 2\n\nYou need to provide some details about the parameter in the generated template."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyMissingOrEmptyDocstring",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyPep8NamingInspection",
+                "shortDescription": {
+                  "text": "PEP 8 naming convention violation"
+                },
+                "fullDescription": {
+                  "text": "Reports violations of the PEP8 naming conventions. Example: 'class mammalia(object):\n    extremities = 4\n\n    def feeds(self):\n        print(\"milk\")' In this code fragment, IDE offers to rename 'mammalia' to 'Mammalia'. When the quick-fix is applied, the code change to: 'class Mammalia(object):\n    extremities = 4\n\n    def feeds(self):\n        print(\"milk\")'",
+                  "markdown": "Reports violations of the\n[PEP8](https://www.python.org/dev/peps/pep-0008/) naming conventions.\n\n**Example:**\n\n\n    class mammalia(object):\n        extremities = 4\n\n        def feeds(self):\n            print(\"milk\")\n\nIn this code fragment, IDE offers to rename `mammalia` to `Mammalia`.\nWhen the quick-fix is applied, the code change to:\n\n\n    class Mammalia(object):\n        extremities = 4\n\n        def feeds(self):\n            print(\"milk\")\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyPep8Naming",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyDictDuplicateKeysInspection",
+                "shortDescription": {
+                  "text": "Dictionary contains duplicate keys"
+                },
+                "fullDescription": {
+                  "text": "Reports using the same value as the dictionary key twice. Example: 'dic = {\"a\": [1, 2], \"a\": [3, 4]}'",
+                  "markdown": "Reports using the same value as the dictionary key twice.\n\n**Example:**\n\n\n    dic = {\"a\": [1, 2], \"a\": [3, 4]}\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyDictDuplicateKeys",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyNoneFunctionAssignmentInspection",
+                "shortDescription": {
+                  "text": "Assigning function calls that don't return anything"
+                },
+                "fullDescription": {
+                  "text": "Reports cases when an assignment is done on a function that does not return anything. This inspection is similar to pylint inspection E1111. Example: 'def just_print():\n    print(\"Hello!\")\n\n\naction = just_print()' As a quick-fix, the IDE offers to remove the assignment.",
+                  "markdown": "Reports cases when an assignment is done on a function that does not return anything.\nThis inspection is similar to [pylint inspection E1111](https://docs.pylint.org/en/1.6.0/features.html#id6).\n\n**Example:**\n\n\n    def just_print():\n        print(\"Hello!\")\n\n\n    action = just_print()\n\nAs a quick-fix, the IDE offers to remove the assignment."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyNoneFunctionAssignment",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyStatementEffectInspection",
+                "shortDescription": {
+                  "text": "Statement has no effect"
+                },
+                "fullDescription": {
+                  "text": "Reports statements that have no effect. Example: 'class Car:\n    def __init__(self, speed=0):\n        self.speed = speed\n        self.time # has no effect\n\n2 + 3 # has no effect' In this example, you can either add a field 'time' to the 'Car' class or introduce variables for the problematic statements.",
+                  "markdown": "Reports statements that have no effect.\n\n**Example:**\n\n\n    class Car:\n        def __init__(self, speed=0):\n            self.speed = speed\n            self.time # has no effect\n\n    2 + 3 # has no effect\n\nIn this example, you can either add a field `time` to the `Car` class or\nintroduce variables for the problematic statements."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyStatementEffect",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyMandatoryEncodingInspection",
+                "shortDescription": {
+                  "text": "No encoding specified for file"
+                },
+                "fullDescription": {
+                  "text": "Reports a missing encoding comment in Python 2. Example: 'class Book(object):\n    def __init__(self):\n        pass' When the quick-fix is applied, the missing comment is added: '# coding=utf-8\nclass Book(object):\n    def __init__(self):\n        pass'",
+                  "markdown": "Reports a missing encoding comment in Python 2.\n\n**Example:**\n\n\n    class Book(object):\n        def __init__(self):\n            pass\n\nWhen the quick-fix is applied, the missing comment is added:\n\n\n    # coding=utf-8\n    class Book(object):\n        def __init__(self):\n            pass\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyMandatoryEncoding",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyInconsistentIndentationInspection",
+                "shortDescription": {
+                  "text": "Inconsistent indentation"
+                },
+                "fullDescription": {
+                  "text": "Reports inconsistent indentation in Python source files when, for example, you use a mixture of tabs and spaces in your code.",
+                  "markdown": "Reports inconsistent indentation in Python source files when, for example,\nyou use a mixture of tabs and spaces in your code."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyInconsistentIndentation",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyAttributeOutsideInitInspection",
+                "shortDescription": {
+                  "text": "An instance attribute is defined outside `__init__`"
+                },
+                "fullDescription": {
+                  "text": "Reports a problem when instance attribute definition is outside '__init__' method. Example: 'class Book:\n    def __init__(self):\n        self.author = 'Mark Twain'\n\n    def release(self):\n        self.year = '1889'' When the quick-fix is applied, the code sample changes to: 'class Book:\n    def __init__(self):\n        self.year = '1889'\n        self.author = 'Mark Twain'\n\n    def release(self):\n        pass'",
+                  "markdown": "Reports a problem when instance attribute definition is outside `__init__` method.\n\n**Example:**\n\n\n        class Book:\n        def __init__(self):\n            self.author = 'Mark Twain'\n\n        def release(self):\n            self.year = '1889'\n\n\nWhen the quick-fix is applied, the code sample changes to:\n\n\n        class Book:\n        def __init__(self):\n            self.year = '1889'\n            self.author = 'Mark Twain'\n\n        def release(self):\n            pass\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyAttributeOutsideInit",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyTypedDictInspection",
+                "shortDescription": {
+                  "text": "Invalid TypedDict definition and usages"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid definition and usage of TypedDict. Example: 'from typing import TypedDict\n\n\nclass Movie(TypedDict):\n    name: str\n    year: int\n    rate: int = 10  # Right-hand side values are not supported\n\n    def method(self): # Invalid statement in TypedDict\n        pass\n\n\nm = Movie(name=\"name\", year=1000, rate=9)\nprint(m[\"director\"])  # There is no the 'director' key in 'Movie'\ndel m[\"name\"]  # The 'name' key cannot be deleted\nm[\"year\"] = \"1001\"  # Expected 'int', got 'str''",
+                  "markdown": "Reports invalid definition and usage of\n[TypedDict](https://www.python.org/dev/peps/pep-0589/).\n\n**Example:**\n\n\n    from typing import TypedDict\n\n\n    class Movie(TypedDict):\n        name: str\n        year: int\n        rate: int = 10  # Right-hand side values are not supported\n\n        def method(self): # Invalid statement in TypedDict\n            pass\n\n\n    m = Movie(name=\"name\", year=1000, rate=9)\n    print(m[\"director\"])  # There is no the 'director' key in 'Movie'\n    del m[\"name\"]  # The 'name' key cannot be deleted\n    m[\"year\"] = \"1001\"  # Expected 'int', got 'str'\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyTypedDict",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyPep8Inspection",
+                "shortDescription": {
+                  "text": "PEP 8 coding style violation"
+                },
+                "fullDescription": {
+                  "text": "Reports violations of the PEP 8 coding style guide by running the bundled pycodestyle.py tool.",
+                  "markdown": "Reports violations of the [PEP 8 coding style guide](https://www.python.org/dev/peps/pep-0008/) by running the bundled [pycodestyle.py](https://github.com/PyCQA/pycodestyle) tool."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyPep8",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyMissingTypeHintsInspection",
+                "shortDescription": {
+                  "text": "Missing type hinting for function definition"
+                },
+                "fullDescription": {
+                  "text": "Reports missing type hints for function declaration in one of the two formats: parameter annotations or a type comment. Select the Only when types are known checkbox if you want the inspection check the types collected from runtime or inferred.",
+                  "markdown": "Reports missing type hints for function declaration in\none of the two formats: parameter annotations or a type comment.\n\nSelect the **Only when types are known** checkbox if you want the inspection check\nthe types collected from runtime or inferred."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyMissingTypeHints",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyTupleItemAssignmentInspection",
+                "shortDescription": {
+                  "text": "Tuple item assignment is prohibited"
+                },
+                "fullDescription": {
+                  "text": "Reports assignments to a tuple item. Example: 't = ('red', 'blue', 'green', 'white')\nt[3] = 'black'' A quick-fix offers to replace the tuple with a list.",
+                  "markdown": "Reports assignments to a tuple item.\n\n**Example:**\n\n\n    t = ('red', 'blue', 'green', 'white')\n    t[3] = 'black'\n\nA quick-fix offers to replace the tuple with a list."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyTupleItemAssignment",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyDunderSlotsInspection",
+                "shortDescription": {
+                  "text": "Invalid usages of classes with  '__slots__' definitions"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid usages of a class with '__slots__' definitions. Example: 'class Foo:\n    __slots__ = ['foo', 'bar']\n\n\nfoo = Foo()\nfoo.baz = 'spam''",
+                  "markdown": "Reports invalid usages of a class with `__slots__` definitions.\n\n**Example:**\n\n\n    class Foo:\n        __slots__ = ['foo', 'bar']\n\n\n    foo = Foo()\n    foo.baz = 'spam'\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyDunderSlots",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyDefaultArgumentInspection",
+                "shortDescription": {
+                  "text": "The default argument is mutable"
+                },
+                "fullDescription": {
+                  "text": "Reports a problem when a mutable value as a list or dictionary is detected in a default value for an argument. Default argument values are evaluated only once at function definition time, which means that modifying the default value of the argument will affect all subsequent calls of that function. Example: 'def func(s, cache={}):\n    cache[s] = None' When the quick-fix is applied, the code changes to: 'def func(s, cache=None):\n    if cache is None:\n        cache = {}\n    cache[s] = None'",
+                  "markdown": "Reports a problem when a mutable value as a list or dictionary is detected in a default value for\nan argument.   \n\nDefault argument values are evaluated only once at function definition time,\nwhich means that modifying the\ndefault value of the argument will affect all subsequent calls of that function.\n\n**Example:**\n\n\n    def func(s, cache={}):\n        cache[s] = None\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    def func(s, cache=None):\n        if cache is None:\n            cache = {}\n        cache[s] = None\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyDefaultArgument",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyTestUnpassedFixtureInspection",
+                "shortDescription": {
+                  "text": "Fixture is not requested by test functions"
+                },
+                "fullDescription": {
+                  "text": "Reports if a fixture is used without being passed to test function parameters or to '@pytest.mark.usefixtures' decorator",
+                  "markdown": "Reports if a fixture is used without being passed to test function parameters or to `@pytest.mark.usefixtures` decorator"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyTestUnpassedFixture",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyShadowingBuiltinsInspection",
+                "shortDescription": {
+                  "text": "Shadowing built-in names"
+                },
+                "fullDescription": {
+                  "text": "Reports shadowing built-in names, such as 'len' or 'list'. Example: 'def len(a, b, c):\n    d = a + b + c\n    return d' In this code fragment, the 'len' built-in name is used. The IDE offers to apply the Rename refactoring as a fix.",
+                  "markdown": "Reports shadowing built-in names, such as `len` or `list`.\n\n**Example:**\n\n\n    def len(a, b, c):\n        d = a + b + c\n        return d\n\nIn this code fragment, the `len` built-in name is used. The IDE offers to\napply the Rename refactoring as a fix."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyShadowingBuiltins",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyMethodOverridingInspection",
+                "shortDescription": {
+                  "text": "Method signature does not match signature of overridden method"
+                },
+                "fullDescription": {
+                  "text": "Reports inconsistencies in overriding method signatures. Example: 'class Book:\n    def add_title(self):\n        pass\n\n\nclass Novel(Book):\n    def add_title(self, text):\n        pass' Parameters of the 'add_title' method in the 'Novel' class do not match the method signature specified in the 'Book' class. As a fix, the IDE offers to apply the Change Signature refactoring.",
+                  "markdown": "Reports inconsistencies in overriding method signatures.\n\n**Example:**\n\n\n    class Book:\n        def add_title(self):\n            pass\n\n\n    class Novel(Book):\n        def add_title(self, text):\n            pass\n\nParameters of the `add_title` method in the `Novel` class do not match the method\nsignature specified in the `Book` class. As a fix, the IDE offers to apply the Change Signature\nrefactoring."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyMethodOverriding",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PoetryPackageVersionsInspection",
+                "shortDescription": {
+                  "text": "Poetry package versions"
+                },
+                "fullDescription": {
+                  "text": "Reports outdated versions of packages in '[tool.poetry.dependencies]' and '[tool.poetry.dev-dependencies]' sections of 'pyproject.toml'.",
+                  "markdown": "Reports outdated versions of packages in `[tool.poetry.dependencies]` and `[tool.poetry.dev-dependencies]`\nsections of `pyproject.toml`."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PoetryPackageVersions",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyTestParametrizedInspection",
+                "shortDescription": {
+                  "text": "Incorrect arguments in @pytest.mark.parametrize"
+                },
+                "fullDescription": {
+                  "text": "Reports functions that are decorated with @pytest.mark.parametrize but do not have arguments to accept parameters of the decorator.",
+                  "markdown": "Reports functions that are decorated with [@pytest.mark.parametrize](https://docs.pytest.org/en/stable/parametrize.html) but do not have arguments to accept\nparameters of the decorator."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyTestParametrized",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyDecoratorInspection",
+                "shortDescription": {
+                  "text": "Class-specific decorator is used outside the class"
+                },
+                "fullDescription": {
+                  "text": "Reports usages of '@classmethod' or '@staticmethod' decorators in methods outside a class. Example: 'class State(object):\n\n    @classmethod\n    def my_state(cls, name):\n        cls.name = name\n\n\n@classmethod\ndef change_state(self):\n    pass' The 'change_state' method should not use the '@classmethod' decorator or it should be moved to the 'State' class declaration. If you apply the 'Remove decorator' action, the code changes to: 'class State(object):\n\n    @classmethod\n    def my_state(cls, name):\n        cls.name = name\n\n\ndef change_state(self):\n    pass'",
+                  "markdown": "Reports usages of `@classmethod` or `@staticmethod` decorators\nin methods outside a class.\n\n**Example:**\n\n\n    class State(object):\n\n        @classmethod\n        def my_state(cls, name):\n            cls.name = name\n\n\n    @classmethod\n    def change_state(self):\n        pass\n\nThe `change_state` method should not use the `@classmethod` decorator or it should be\nmoved to the `State` class declaration.\n\nIf you apply the `Remove decorator` action, the code changes to:\n\n\n    class State(object):\n\n        @classmethod\n        def my_state(cls, name):\n            cls.name = name\n\n\n    def change_state(self):\n        pass\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyDecorator",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyAsyncCallInspection",
+                "shortDescription": {
+                  "text": "Missing `await` syntax in coroutine calls"
+                },
+                "fullDescription": {
+                  "text": "Reports coroutines that were called without using the 'await' syntax. Example: 'async def bar():\n    pass\n\n\nasync def foo():\n    bar()' After the quick-fix is applied, the code changes to: 'async def bar():\n    pass\n\n\nasync def foo():\n    await bar()'",
+                  "markdown": "Reports coroutines that were called\nwithout using the `await` syntax.\n\n**Example:**\n\n\n    async def bar():\n        pass\n\n\n    async def foo():\n        bar()\n\nAfter the quick-fix is applied, the code changes to:\n\n\n    async def bar():\n        pass\n\n\n    async def foo():\n        await bar()\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyAsyncCall",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RestRoleInspection",
+                "shortDescription": {
+                  "text": "Role is not defined"
+                },
+                "fullDescription": {
+                  "text": "Reports undefined roles in reStructuredText files. Example: '.. role:: custom\n.. role:: newcustom(emphasis)\n\nAn example of using :custom:`interpreted text`\nAn example of using :newcustom:`interpreted text`\nAn example of using :emphasis:`interpreted text`\n\n\nSome text using undefined role :undef:`interpreted text`'",
+                  "markdown": "Reports undefined roles in reStructuredText files.\n\n**Example:**\n\n\n    .. role:: custom\n    .. role:: newcustom(emphasis)\n\n    An example of using :custom:`interpreted text`\n    An example of using :newcustom:`interpreted text`\n    An example of using :emphasis:`interpreted text`\n\n\n    Some text using undefined role :undef:`interpreted text`\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RestRoleInspection",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "ReST",
+                      "index": 59,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "CommandLineInspection",
+                "shortDescription": {
+                  "text": "Incorrect CLI syntax"
+                },
+                "fullDescription": {
+                  "text": "Reports the problems if the arguments of the command you type in the console are not in the proper order. The inspection also verifies that option names and arguments are correct. Do not disable the inspection if you are going to use command-line interfaces like manage.py in Django.",
+                  "markdown": "Reports the problems if the arguments of the command you type in the console are not in the proper order. The inspection also verifies\nthat option names and arguments are correct.\n\nDo not disable the inspection if you are going to use command-line interfaces like [manage.py in Django](https://www.jetbrains.com/help/pycharm/running-manage-py.html)."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "CommandLineInspection",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyComparisonWithNoneInspection",
+                "shortDescription": {
+                  "text": "Using equality operators to compare with None"
+                },
+                "fullDescription": {
+                  "text": "Reports comparisons with 'None'. That type of comparisons should always be done with 'is' or 'is not', never the equality operators. Example: 'a = 2\n\n\nif a == None:\n    print(\"Success\")' Once the quick-fix is applied, the code changes to: 'a = 2\n\n\nif a is None:\n    print(\"Success\")'",
+                  "markdown": "Reports comparisons with `None`. That type of comparisons\nshould always be done with `is` or `is not`, never\nthe equality operators.\n\n**Example:**\n\n\n    a = 2\n\n\n    if a == None:\n        print(\"Success\")\n\nOnce the quick-fix is applied, the code changes to:\n\n\n    a = 2\n\n\n    if a is None:\n        print(\"Success\")\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyComparisonWithNone",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyMethodParametersInspection",
+                "shortDescription": {
+                  "text": "Improper first parameter"
+                },
+                "fullDescription": {
+                  "text": "Reports methods that lack the first parameter that is usually named 'self'. Example: 'class Movie:\n\n   def show():\n       pass' When the quick-fix is applied, the code changes to: 'class Movie:\n\n   def show(self):\n       pass' The inspection also reports naming issues in class methods. Example: 'class Movie:\n    @classmethod\n    def show(abc):\n        pass' Since the first parameter of a class method should be 'cls', the IDE provides a quick-fix to rename it.",
+                  "markdown": "Reports methods that lack the first parameter that is usually\nnamed `self`.\n\n**Example:**\n\n\n    class Movie:\n\n       def show():\n           pass\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    class Movie:\n\n       def show(self):\n           pass\n\nThe inspection also reports naming issues in class methods.\n\n**Example:**\n\n\n    class Movie:\n        @classmethod\n        def show(abc):\n            pass\n\nSince the first parameter of a class method should be `cls`, the IDE provides a quick-fix\nto rename it."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyMethodParameters",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyDocstringTypesInspection",
+                "shortDescription": {
+                  "text": "Type in docstring does not match inferred type"
+                },
+                "fullDescription": {
+                  "text": "Reports types in docstring that do not match dynamically inferred types.",
+                  "markdown": "Reports types in docstring that do not match dynamically inferred types."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyDocstringTypes",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyMethodFirstArgAssignmentInspection",
+                "shortDescription": {
+                  "text": "First argument of the method is reassigned"
+                },
+                "fullDescription": {
+                  "text": "Reports cases when the first parameter, such as 'self' or 'cls', is reassigned in a method. Because in most cases, there are no objectives in such reassignment, the IDE indicates an error. Example: 'class Account:\n    def calc(self, balance):\n        if balance == 0:\n            self = balance\n        return self' As a fix, you might want to check and modify the algorithm to ensure that reassignment is needed. If everything is correct, you can invoke intention actions for this code and opt to ignore the warning.",
+                  "markdown": "Reports cases when the first parameter,\nsuch as `self` or `cls`, is reassigned in a method.\nBecause in most cases, there are no objectives in such reassignment, the\nIDE indicates an error.\n\n**Example:**\n\n\n    class Account:\n        def calc(self, balance):\n            if balance == 0:\n                self = balance\n            return self\n\nAs a fix, you might want to check and modify the algorithm to ensure that reassignment is needed. If everything is correct,\nyou can invoke intention actions for this code and opt to ignore the warning."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyMethodFirstArgAssignment",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyNewStyleGenericSyntaxInspection",
+                "shortDescription": {
+                  "text": "Invalid usage of new-style type parameters and type aliases"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid usage of PEP 695 type parameter syntax Finds the following problems in function and class definitions and new-style type alias statements: Extending typing.Generic in new-style generic classes Extending parameterized typing.Protocol in new-style generic classes Using generic upper bounds and constraints with type parameters for ParamSpec and TypeVarTuple Mixing traditional and new-style type variables Using traditional type variables in new-style type aliases Examples: 'from typing import Generic\n\n  class Example[T](Generic[T]): ... # Classes with type parameter list should not extend 'Generic'' 'class Example[T: (list[S], str)]: ... # Generic types are not allowed inside constraints and bounds of type parameters' 'from typing import TypeVar\n\n  K = TypeVar(\"K\")\n\n  class ClassC[V]:\n      def method2[M](self, a: M, b: K) -> M | K: ... # Mixing traditional and new-style TypeVars is not allowed'",
+                  "markdown": "Reports invalid usage of [PEP 695](https://www.python.org/dev/peps/pep-0695/) type parameter syntax\n\n\nFinds the following problems in function and class definitions and new-style type alias statements:\n\n* Extending typing.Generic in new-style generic classes\n* Extending parameterized typing.Protocol in new-style generic classes\n* Using generic upper bounds and constraints with type parameters for ParamSpec and TypeVarTuple\n* Mixing traditional and new-style type variables\n* Using traditional type variables in new-style type aliases\n\n\nExamples:\n\n\n      from typing import Generic\n\n      class Example[T](Generic[T]): ... # Classes with type parameter list should not extend 'Generic'\n\n\n      class Example[T: (list[S], str)]: ... # Generic types are not allowed inside constraints and bounds of type parameters\n\n\n      from typing import TypeVar\n\n      K = TypeVar(\"K\")\n\n      class ClassC[V]:\n          def method2[M](self, a: M, b: K) -> M | K: ... # Mixing traditional and new-style TypeVars is not allowed\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyNewStyleGenericSyntax",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyTupleAssignmentBalanceInspection",
+                "shortDescription": {
+                  "text": "Tuple assignment balance is incorrect"
+                },
+                "fullDescription": {
+                  "text": "Reports cases when the number of expressions on the right-hand side and targets on the left-hand side are not the same. Example: 't = ('red', 'blue', 'green', 'white')\n(c1, c2, c3) = t' As a quick-fix, you can modify the highlighted code fragment to restore the tuple balance.",
+                  "markdown": "Reports cases when the number of expressions on the right-hand side\nand targets on the left-hand side are not the same.\n\n**Example:**\n\n\n    t = ('red', 'blue', 'green', 'white')\n    (c1, c2, c3) = t\n\nAs a quick-fix, you can modify the highlighted code fragment to restore the tuple\nbalance."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyTupleAssignmentBalance",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyClassHasNoInitInspection",
+                "shortDescription": {
+                  "text": "Class has no `__init__` method"
+                },
+                "fullDescription": {
+                  "text": "Reports cases in Python 2 when a class has no '__init__' method, neither its parent classes. Example: 'class Book():\n    pass' The quick-fix adds the '__init__' method: 'class Book():\n    def __init__(self):\n        pass'",
+                  "markdown": "Reports cases in Python 2 when a class has no `__init__` method, neither its parent\nclasses.\n\n**Example:**\n\n\n    class Book():\n        pass\n\nThe quick-fix adds the `__init__` method:\n\n\n    class Book():\n        def __init__(self):\n            pass\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyClassHasNoInit",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyArgumentEqualDefaultInspection",
+                "shortDescription": {
+                  "text": "The function argument is equal to the default parameter value"
+                },
+                "fullDescription": {
+                  "text": "Reports a problem when an argument passed to the function is equal to the default parameter value. This inspection is disabled by default to avoid performance degradation. Example: 'def my_function(a: int = 2):\n    print(a)\n\n\nmy_function(2)'",
+                  "markdown": "Reports a problem when an argument\npassed to the function is equal to the default parameter value.\n\nThis inspection is disabled by default to avoid performance degradation.\n\n**Example:**\n\n\n    def my_function(a: int = 2):\n        print(a)\n\n\n    my_function(2)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyArgumentEqualDefault",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyClassVarInspection",
+                "shortDescription": {
+                  "text": "Invalid usage of ClassVar variables"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid usages of ClassVar annotations. Example: 'from typing import ClassVar\n\n\nclass Cat:\n    color: ClassVar[str] = \"white\"\n    weight: int\n\n    def __init__(self, weight: int):\n        self.weight = weight\n\n\nCat.color = \"black\"  # OK\nmy_cat = Cat(5)\nmy_cat.color = \"gray\"  # Error, setting class variable on instance'",
+                  "markdown": "Reports invalid usages of [ClassVar](https://docs.python.org/3/library/typing.html#typing.ClassVar) annotations.\n\n**Example:**\n\n\n    from typing import ClassVar\n\n\n    class Cat:\n        color: ClassVar[str] = \"white\"\n        weight: int\n\n        def __init__(self, weight: int):\n            self.weight = weight\n\n\n    Cat.color = \"black\"  # OK\n    my_cat = Cat(5)\n    my_cat.color = \"gray\"  # Error, setting class variable on instance\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyClassVar",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyFromFutureImportInspection",
+                "shortDescription": {
+                  "text": "Improper position of from __future__ import"
+                },
+                "fullDescription": {
+                  "text": "Reports 'from __future__ import' statements that are used not at the beginning of a file. Example: 'a = 1\nfrom __future__ import print_function\nprint()' When the quick-fix is applied, the code changes to: 'from __future__ import print_function\n\na = 1\nprint()'",
+                  "markdown": "Reports `from __future__ import`\nstatements that are used not at\nthe beginning of a file.\n\n**Example:**\n\n\n    a = 1\n    from __future__ import print_function\n    print()\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    from __future__ import print_function\n\n    a = 1\n    print()\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyFromFutureImport",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyUnresolvedReferencesInspection",
+                "shortDescription": {
+                  "text": "Unresolved references"
+                },
+                "fullDescription": {
+                  "text": "Reports references in your code that cannot be resolved. In a dynamically typed language, this is possible in a limited number of cases. If a reference type is unknown, then its attributes are not highlighted as unresolved even if you know that they should be: 'def print_string(s):\n  print(s.abc())' In this code fragment 's' is always a string and 'abc' should be highlighted as unresolved. However, 's' type is inferred as 'Any' and no warning is reported. The IDE provides quick-fix actions to add missing references on-the-fly.",
+                  "markdown": "Reports references in your code that cannot be resolved.\n\nIn a dynamically typed language, this is possible in a limited number of cases.\n\nIf a reference type is unknown, then its attributes are not highlighted as unresolved even if you know that they should be:\n\n\n    def print_string(s):\n      print(s.abc())\n\nIn this code fragment `s` is always a string and `abc` should be highlighted as unresolved. However, `s`\ntype is inferred as `Any` and no warning is reported.\n\nThe IDE provides quick-fix actions to add missing references on-the-fly."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyUnresolvedReferences",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyPackageRequirementsInspection",
+                "shortDescription": {
+                  "text": "Unsatisfied package requirements"
+                },
+                "fullDescription": {
+                  "text": "Reports packages mentioned in requirements files (for example, 'requirements.txt' or 'Pipfile') but not installed, or imported but not mentioned in requirements files. The IDE shows a quick-fix banner so that you can install the missing packages in one click.",
+                  "markdown": "Reports packages mentioned in requirements files (for example, `requirements.txt` or `Pipfile`) but not installed,\nor imported but not mentioned in requirements files.\n\n\nThe IDE shows a quick-fix banner so that you can install the missing packages in one click."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyPackageRequirements",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyRedundantParenthesesInspection",
+                "shortDescription": {
+                  "text": "Redundant parentheses"
+                },
+                "fullDescription": {
+                  "text": "Reports about redundant parentheses in expressions. The IDE provides the quick-fix action to remove the redundant parentheses.",
+                  "markdown": "Reports about redundant parentheses in expressions.\n\nThe IDE provides the quick-fix action to remove the redundant parentheses."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyRedundantParentheses",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyTrailingSemicolonInspection",
+                "shortDescription": {
+                  "text": "Prohibited trailing semicolon in a statement"
+                },
+                "fullDescription": {
+                  "text": "Reports trailing semicolons in statements. Example: 'def my_func(a):\n    c = a ** 2;\n    return c' IDE provides a quick-fix that removes a trailing semicolon. When you apply it, the code changes to: 'def my_func(a):\n    c = a ** 2\n    return c'",
+                  "markdown": "Reports trailing semicolons in statements.\n\n**Example:**\n\n\n    def my_func(a):\n        c = a ** 2;\n        return c\n\nIDE provides a quick-fix that removes a trailing semicolon. When you\napply it, the code changes to:\n\n\n    def my_func(a):\n        c = a ** 2\n        return c\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyTrailingSemicolon",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyArgumentListInspection",
+                "shortDescription": {
+                  "text": "Incorrect call arguments"
+                },
+                "fullDescription": {
+                  "text": "Reports discrepancies between declared parameters and actual arguments, as well as incorrect arguments, for example, duplicate named arguments, and incorrect argument order. Example: 'class Foo:\n    def __call__(self, p1: int, *, p2: str = \"%\"):\n        return p2 * p1\n\n\nbar = Foo()\nbar.__call__() # unfilled parameter\nbar(5, \"#\") # unexpected argument' The correct code fragment looks at follows: 'class Foo:\n    def __call__(self, p1: int, *, p2: str = \"%\"):\n        return p2 * p1\n\n\nbar = Foo()\nbar.__call__(5)\nbar(5, p2=\"#\")'",
+                  "markdown": "Reports discrepancies between declared parameters and actual arguments, as well as\nincorrect arguments, for example, duplicate named arguments, and incorrect argument order.\n\n**Example:**\n\n\n    class Foo:\n        def __call__(self, p1: int, *, p2: str = \"%\"):\n            return p2 * p1\n\n\n    bar = Foo()\n    bar.__call__() # unfilled parameter\n    bar(5, \"#\") # unexpected argument\n\nThe correct code fragment looks at follows:\n\n\n    class Foo:\n        def __call__(self, p1: int, *, p2: str = \"%\"):\n            return p2 * p1\n\n\n    bar = Foo()\n    bar.__call__(5)\n    bar(5, p2=\"#\")\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyArgumentList",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyInterpreterInspection",
+                "shortDescription": {
+                  "text": "An invalid interpreter"
+                },
+                "fullDescription": {
+                  "text": "Reports problems if there is no Python interpreter configured for the project or if the interpreter is invalid. Without a properly configured interpreter, you cannot execute your Python scripts and benefit from some Python code insight features. The IDE provides quick access to the interpreter settings.",
+                  "markdown": "Reports problems if there is no Python interpreter configured for the project or if the interpreter is invalid. Without a properly\nconfigured interpreter, you cannot execute your Python scripts and benefit from some Python code insight features.\n\nThe IDE provides quick access to the interpreter settings."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyInterpreter",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyPropertyAccessInspection",
+                "shortDescription": {
+                  "text": "Inappropriate access to properties"
+                },
+                "fullDescription": {
+                  "text": "Reports cases when properties are accessed inappropriately: Read-only properties are set Write-only properties are read Non-deletable properties are deleted Example: 'class MyClass:\n    @property\n    def read_only(self): return None\n\n    def __write_only_setter(self, value): pass\n\n    write_only = property(None, __write_only_setter)\n\n\na = MyClass()\na.read_only = 10 # property cannot be set\ndel a.read_only # property cannot be deleted\nprint(a.write_only) # property cannot be read'",
+                  "markdown": "Reports cases when properties are accessed inappropriately:\n\n* Read-only properties are set\n* Write-only properties are read\n* Non-deletable properties are deleted\n\n**Example:**\n\n\n    class MyClass:\n        @property\n        def read_only(self): return None\n\n        def __write_only_setter(self, value): pass\n\n        write_only = property(None, __write_only_setter)\n\n\n    a = MyClass()\n    a.read_only = 10 # property cannot be set\n    del a.read_only # property cannot be deleted\n    print(a.write_only) # property cannot be read\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyPropertyAccess",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyStubPackagesAdvertiser",
+                "shortDescription": {
+                  "text": "Stub packages advertiser"
+                },
+                "fullDescription": {
+                  "text": "Reports availability of stub packages. Stub package is a package that contains type information for the corresponding runtime package. Using stub packages ensures better coding assistance for the corresponding python package.",
+                  "markdown": "Reports availability of stub packages.\n\n\n[Stub package](https://www.python.org/dev/peps/pep-0561/) is a package that contains type information for the corresponding\nruntime package.\n\nUsing stub packages ensures better coding assistance for the corresponding python package."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyStubPackagesAdvertiser",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyRelativeImportInspection",
+                "shortDescription": {
+                  "text": "Suspicious relative imports"
+                },
+                "fullDescription": {
+                  "text": "Reports usages of relative imports inside plain directories, for example, directories neither containing '__init__.py' nor explicitly marked as namespace packages.",
+                  "markdown": "Reports usages of relative imports inside plain directories, for example, directories neither containing `__init__.py` nor\nexplicitly marked as namespace packages."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyPackages",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyRedeclarationInspection",
+                "shortDescription": {
+                  "text": "Redeclared names without usages"
+                },
+                "fullDescription": {
+                  "text": "Reports unconditional redeclarations of names without being used in between. Example: 'def x(): pass\n\n\nx = 2' It applies to function and class declarations, and top-level assignments. When the warning is shown, you can try a recommended action, for example, you might be prompted to rename the variable.",
+                  "markdown": "Reports unconditional redeclarations of names without being used in between.\n\n**Example:**\n\n\n    def x(): pass\n\n\n    x = 2\n\nIt applies to function and class declarations, and top-level assignments.\n\nWhen the warning is shown, you can try a recommended action, for example, you might be prompted to\nrename the variable."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyRedeclaration",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyramidSetupInspection",
+                "shortDescription": {
+                  "text": "Project is not installed for development"
+                },
+                "fullDescription": {
+                  "text": "Reports cases when no 'python setup.py develop' command was executed for the Pyramid project. You need to execute this command to install the newly created project for development.",
+                  "markdown": "Reports cases when no `python setup.py develop` command was executed for the Pyramid project.\n\nYou need to execute this command to install the newly created project for development."
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyramidSetup",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Pyramid",
+                      "index": 63,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyProtectedMemberInspection",
+                "shortDescription": {
+                  "text": "Accessing a protected member of a class or a module"
+                },
+                "fullDescription": {
+                  "text": "Reports cases when a protected member is accessed outside the class, a descendant of the class where it is defined, or a module. Example: 'class Foo:\n    def _protected_method(self):\n        pass\n\n\nclass Bar(Foo):\n    def public_method(self):\n        self._protected_method()\n\n\nfoo = Foo()\nfoo._protected_method() # Access to a protected method'",
+                  "markdown": "Reports cases when a protected member is accessed outside the class,\na descendant of the class where it is defined, or a module.\n\n**Example:**\n\n\n    class Foo:\n        def _protected_method(self):\n            pass\n\n\n    class Bar(Foo):\n        def public_method(self):\n            self._protected_method()\n\n\n    foo = Foo()\n    foo._protected_method() # Access to a protected method\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyProtectedMember",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyStubPackagesCompatibilityInspection",
+                "shortDescription": {
+                  "text": "Incompatible stub packages"
+                },
+                "fullDescription": {
+                  "text": "Reports stub packages that do not support the version of the corresponding runtime package. A stub package contains type information for some runtime package.",
+                  "markdown": "Reports stub packages that do not support the version of the corresponding runtime package.\n\nA [stub package](https://www.python.org/dev/peps/pep-0561/) contains type information for some runtime package."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyStubPackagesCompatibility",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyUnboundLocalVariableInspection",
+                "shortDescription": {
+                  "text": "Unbound local variables"
+                },
+                "fullDescription": {
+                  "text": "Reports local variables referenced before assignment. Example: 'x = 0\nif x > 10:\n    b = 3\nprint(b)' The IDE reports a problem for 'print(b)'. A possible fix is: 'x = 0\nif x > 10:\n    b = 3\n    print(b)'",
+                  "markdown": "Reports local variables referenced before assignment.\n\n**Example:**\n\n\n    x = 0\n    if x > 10:\n        b = 3\n    print(b)\n\nThe IDE reports a problem for `print(b)`. A possible fix is:\n\n\n    x = 0\n    if x > 10:\n        b = 3\n        print(b)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyUnboundLocalVariable",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyNamedTupleInspection",
+                "shortDescription": {
+                  "text": "Invalid definition of 'typing.NamedTuple'"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid definition of a typing.NamedTuple. Example: 'import typing\n\n\nclass FullName(typing.NamedTuple):\n    first: str\n    last: str = \"\"\n    middle: str' As a fix, place the field with the default value after the fields without default values: 'import typing\n\n\nclass FullName(typing.NamedTuple):\n    first: str\n    middle: str\n    last: str = \"\"'",
+                  "markdown": "Reports invalid definition of a\n[typing.NamedTuple](https://docs.python.org/3/library/typing.html#typing.NamedTuple).\n\n**Example:**\n\n\n    import typing\n\n\n    class FullName(typing.NamedTuple):\n        first: str\n        last: str = \"\"\n        middle: str\n\nAs a fix, place the field with the default value after the fields without default values:\n\n\n    import typing\n\n\n    class FullName(typing.NamedTuple):\n        first: str\n        middle: str\n        last: str = \"\"\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyNamedTuple",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyNestedDecoratorsInspection",
+                "shortDescription": {
+                  "text": "Problematic nesting of decorators"
+                },
+                "fullDescription": {
+                  "text": "Reports problems with nesting decorators. The inspection highlights the cases when 'classmethod' or 'staticmethod' is applied before another decorator. Example: 'def innocent(f):\n    return f\n\n\nclass A:\n    @innocent  # Decorator will not receive a callable it may expect\n    @classmethod\n    def f2(cls):\n        pass\n\n    @innocent  # Decorator will not receive a callable it may expect\n    @staticmethod\n    def f1():\n        pass' As a quick-fix, the IDE offers to remove the decorator.",
+                  "markdown": "Reports problems with nesting decorators. The inspection highlights the cases when `classmethod` or `staticmethod`\nis applied before another decorator.\n\n**Example:**\n\n\n    def innocent(f):\n        return f\n\n\n    class A:\n        @innocent  # Decorator will not receive a callable it may expect\n        @classmethod\n        def f2(cls):\n            pass\n\n        @innocent  # Decorator will not receive a callable it may expect\n        @staticmethod\n        def f1():\n            pass\n\nAs a quick-fix, the IDE offers to remove the decorator."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyNestedDecorators",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyOverloadsInspection",
+                "shortDescription": {
+                  "text": "Overloads in regular Python files"
+                },
+                "fullDescription": {
+                  "text": "Reports cases when overloads in regular Python files are placed after the implementation or when their signatures are not compatible with the implementation. Example: 'from typing import overload\n\n\n@overload\ndef foo(p1, p2): # Overload signature is not compatible with the implementation\n    pass\n\n\n@overload\ndef foo(p1): # Overload signature is not compatible with the implementation\n    pass\n\n\ndef foo(p1, p2, p3):\n    print(p1, p2, p3)'",
+                  "markdown": "Reports cases when overloads in regular Python files are placed after the implementation or when their signatures are\nnot compatible with the implementation.\n\n**Example:**\n\n\n    from typing import overload\n\n\n    @overload\n    def foo(p1, p2): # Overload signature is not compatible with the implementation\n        pass\n\n\n    @overload\n    def foo(p1): # Overload signature is not compatible with the implementation\n        pass\n\n\n    def foo(p1, p2, p3):\n        print(p1, p2, p3)\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyOverloads",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyExceptClausesOrderInspection",
+                "shortDescription": {
+                  "text": "Wrong order of 'except' clauses"
+                },
+                "fullDescription": {
+                  "text": "Reports cases when 'except' clauses are not in the proper order, from the more specific to the more generic, or one exception class is caught twice. If you do not fix the order, some exceptions may not be caught by the most specific handler. Example: 'try:\n    call()\nexcept ValueError:\n    pass\nexcept UnicodeError:\n    pass' The IDE recommends moving the clause up. When the quick-fix is applied, the code changes to: 'try:\n    call()\nexcept UnicodeError:\n    pass\nexcept ValueError:\n    pass'",
+                  "markdown": "Reports cases when `except` clauses are not in the proper order,\nfrom the more specific to the more generic, or one exception class is caught twice.\n\n\nIf you do not fix the order, some exceptions may not be caught by the most specific handler.\n\n**Example:**\n\n\n    try:\n        call()\n    except ValueError:\n        pass\n    except UnicodeError:\n        pass\n\nThe IDE recommends moving the clause up. When the quick-fix is applied, the code changes to:\n\n\n    try:\n        call()\n    except UnicodeError:\n        pass\n    except ValueError:\n        pass\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyExceptClausesOrder",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyDataclassInspection",
+                "shortDescription": {
+                  "text": "Invalid definition and usage of Data Classes"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid definitions and usages of classes created with 'dataclasses' or 'attr' modules. Example: 'import dataclasses\n\n\n@dataclasses.dataclass\nclass FullName:\n    first: str\n    middle: str = \"\"\n    last: str'",
+                  "markdown": "Reports invalid definitions and usages of classes created with\n`dataclasses` or `attr` modules.\n\n**Example:**\n\n\n    import dataclasses\n\n\n    @dataclasses.dataclass\n    class FullName:\n        first: str\n        middle: str = \"\"\n        last: str\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyDataclass",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyClassicStyleClassInspection",
+                "shortDescription": {
+                  "text": "Classic style class usage"
+                },
+                "fullDescription": {
+                  "text": "Reports classic style classes usage. This inspection applies only to Python 2. Example: 'class A:\n    pass' With quick-fixes provided by the IDE, this code fragment changes to: 'class A(object):\n    def __init__(self):\n        pass'",
+                  "markdown": "Reports [classic style classes](https://docs.python.org/2/reference/datamodel.html#new-style-and-classic-classes) usage. This inspection applies only to Python 2.\n\n**Example:**\n\n\n    class A:\n        pass\n\nWith quick-fixes provided by the IDE, this code fragment changes to:\n\n\n    class A(object):\n        def __init__(self):\n            pass\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyClassicStyleClass",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyPropertyDefinitionInspection",
+                "shortDescription": {
+                  "text": "Incorrect property definition"
+                },
+                "fullDescription": {
+                  "text": "Reports problems with the arguments of 'property()' and functions annotated with '@property'. 'class C:\n    @property\n    def abc(self):  # Getter should return or yield something\n        pass\n\n    @abc.setter\n    def foo(self, value):  # Names of function and decorator don't match\n        pass\n\n    @abc.setter\n    def abc(self, v1, v2):  # Setter signature should be (self, value)\n        pass\n\n    @abc.deleter\n    def abc(self, v1):  # Delete signature should be (self)\n        pass' A quick-fix offers to update parameters.",
+                  "markdown": "Reports problems with the arguments of `property()` and functions\nannotated with `@property`.\n\n\n    class C:\n        @property\n        def abc(self):  # Getter should return or yield something\n            pass\n\n        @abc.setter\n        def foo(self, value):  # Names of function and decorator don't match\n            pass\n\n        @abc.setter\n        def abc(self, v1, v2):  # Setter signature should be (self, value)\n            pass\n\n        @abc.deleter\n        def abc(self, v1):  # Delete signature should be (self)\n            pass\n\nA quick-fix offers to update parameters."
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "PyPropertyDefinition",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyIncorrectDocstringInspection",
+                "shortDescription": {
+                  "text": "Incorrect docstring"
+                },
+                "fullDescription": {
+                  "text": "Reports mismatched parameters in a docstring. For example, 'b' is highlighted, because there is no such a parameter in the 'add' function. 'def add(a, c):\n    \"\"\"\n    @param a:\n    @param b:\n    @return:\n    \"\"\"\n    pass' The inspection does not warn you of missing parameters if none of them is mentioned in a docstring: 'def mult(a, c):\n    \"\"\"\n    @return:\n    \"\"\"\n    pass'",
+                  "markdown": "Reports mismatched parameters in a docstring. For example, `b` is highlighted, because there is no\nsuch a parameter in the `add` function.\n\n\n        def add(a, c):\n        \"\"\"\n        @param a:\n        @param b:\n        @return:\n        \"\"\"\n        pass\n\nThe inspection does not warn you of missing parameters if none of them is mentioned in a docstring:\n\n\n    def mult(a, c):\n        \"\"\"\n        @return:\n        \"\"\"\n        pass\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyIncorrectDocstring",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "PyListCreationInspection",
+                "shortDescription": {
+                  "text": "Non-optimal list declaration"
+                },
+                "fullDescription": {
+                  "text": "Reports cases when a list declaration can be rewritten with a list literal. This ensures better performance of your application. Example: 'l = [1]\nl.append(2)' When the quick-fix is applied, the code changes to: 'l = [1, 2]'",
+                  "markdown": "Reports cases when a list declaration\ncan be rewritten with a list literal.\n\nThis ensures better performance of your application.\n\n**Example:**\n\n\n    l = [1]\n    l.append(2)\n\nWhen the quick-fix is applied, the code changes to:\n\n\n    l = [1, 2]\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "note",
+                  "parameters": {
+                    "suppressToolId": "PyListCreation",
+                    "ideaSeverity": "WEAK WARNING",
+                    "qodanaSeverity": "Moderate"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "Python",
+                      "index": 3,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -13552,39 +13552,6 @@
                 ]
               },
               {
-                "id": "RegExpRedundantNestedCharacterClass",
-                "shortDescription": {
-                  "text": "Redundant nested character class"
-                },
-                "fullDescription": {
-                  "text": "Reports unnecessary nested character classes. Example: '[a-c[x-z]]' After the quick-fix is applied: '[a-cx-z]' New in 2020.2",
-                  "markdown": "Reports unnecessary nested character classes.\n\n**Example:**\n\n\n      [a-c[x-z]]\n\nAfter the quick-fix is applied:\n\n\n      [a-cx-z]\n\nNew in 2020.2"
-                },
-                "defaultConfiguration": {
-                  "enabled": true,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "RegExpRedundantNestedCharacterClass",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "RegExp",
-                      "index": 43,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
                 "id": "XmlDeprecatedElement",
                 "shortDescription": {
                   "text": "Deprecated symbol"
@@ -13607,6 +13574,39 @@
                     "target": {
                       "id": "XML",
                       "index": 39,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "RegExpRedundantNestedCharacterClass",
+                "shortDescription": {
+                  "text": "Redundant nested character class"
+                },
+                "fullDescription": {
+                  "text": "Reports unnecessary nested character classes. Example: '[a-c[x-z]]' After the quick-fix is applied: '[a-cx-z]' New in 2020.2",
+                  "markdown": "Reports unnecessary nested character classes.\n\n**Example:**\n\n\n      [a-c[x-z]]\n\nAfter the quick-fix is applied:\n\n\n      [a-cx-z]\n\nNew in 2020.2"
+                },
+                "defaultConfiguration": {
+                  "enabled": true,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "RegExpRedundantNestedCharacterClass",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "RegExp",
+                      "index": 43,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -13981,19 +13981,19 @@
                 ]
               },
               {
-                "id": "RegExpRepeatedSpace",
+                "id": "RegExpDuplicateAlternationBranch",
                 "shortDescription": {
-                  "text": "Consecutive spaces"
+                  "text": "Duplicate branch in alternation"
                 },
                 "fullDescription": {
-                  "text": "Reports multiple consecutive spaces in a RegExp. Because spaces are not visible by default, it can be hard to see how many spaces are required. The RegExp can be made more clear by replacing the consecutive spaces with a single space and a counted quantifier. Example: '(     )' After the quick-fix is applied: '( {5})' New in 2017.1",
-                  "markdown": "Reports multiple consecutive spaces in a RegExp. Because spaces are not visible by default, it can be hard to see how many spaces are required. The RegExp can be made more clear by replacing the consecutive spaces with a single space and a counted quantifier.\n\n**Example:**\n\n\n      (     )\n\nAfter the quick-fix is applied:\n\n\n      ( {5})\n\n\nNew in 2017.1"
+                  "text": "Reports duplicate branches in a RegExp alternation. Duplicate branches slow down matching and obscure the intent of the expression. Example: '(alpha|bravo|charlie|alpha)' After the quick-fix is applied: '(alpha|bravo|charlie)' New in 2017.1",
+                  "markdown": "Reports duplicate branches in a RegExp alternation. Duplicate branches slow down matching and obscure the intent of the expression.\n\n**Example:**\n\n\n      (alpha|bravo|charlie|alpha)\n\nAfter the quick-fix is applied:\n\n\n      (alpha|bravo|charlie)\n\nNew in 2017.1"
                 },
                 "defaultConfiguration": {
                   "enabled": true,
                   "level": "warning",
                   "parameters": {
-                    "suppressToolId": "RegExpRepeatedSpace",
+                    "suppressToolId": "RegExpDuplicateAlternationBranch",
                     "ideaSeverity": "WARNING",
                     "qodanaSeverity": "High"
                   }
@@ -14014,19 +14014,19 @@
                 ]
               },
               {
-                "id": "RegExpDuplicateAlternationBranch",
+                "id": "RegExpRepeatedSpace",
                 "shortDescription": {
-                  "text": "Duplicate branch in alternation"
+                  "text": "Consecutive spaces"
                 },
                 "fullDescription": {
-                  "text": "Reports duplicate branches in a RegExp alternation. Duplicate branches slow down matching and obscure the intent of the expression. Example: '(alpha|bravo|charlie|alpha)' After the quick-fix is applied: '(alpha|bravo|charlie)' New in 2017.1",
-                  "markdown": "Reports duplicate branches in a RegExp alternation. Duplicate branches slow down matching and obscure the intent of the expression.\n\n**Example:**\n\n\n      (alpha|bravo|charlie|alpha)\n\nAfter the quick-fix is applied:\n\n\n      (alpha|bravo|charlie)\n\nNew in 2017.1"
+                  "text": "Reports multiple consecutive spaces in a RegExp. Because spaces are not visible by default, it can be hard to see how many spaces are required. The RegExp can be made more clear by replacing the consecutive spaces with a single space and a counted quantifier. Example: '(     )' After the quick-fix is applied: '( {5})' New in 2017.1",
+                  "markdown": "Reports multiple consecutive spaces in a RegExp. Because spaces are not visible by default, it can be hard to see how many spaces are required. The RegExp can be made more clear by replacing the consecutive spaces with a single space and a counted quantifier.\n\n**Example:**\n\n\n      (     )\n\nAfter the quick-fix is applied:\n\n\n      ( {5})\n\n\nNew in 2017.1"
                 },
                 "defaultConfiguration": {
                   "enabled": true,
                   "level": "warning",
                   "parameters": {
-                    "suppressToolId": "RegExpDuplicateAlternationBranch",
+                    "suppressToolId": "RegExpRepeatedSpace",
                     "ideaSeverity": "WARNING",
                     "qodanaSeverity": "High"
                   }
@@ -14212,7 +14212,7 @@
                   {
                     "target": {
                       "id": "MySQL",
-                      "index": 13,
+                      "index": 12,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -14278,7 +14278,7 @@
                   {
                     "target": {
                       "id": "MySQL",
-                      "index": 13,
+                      "index": 12,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -14488,19 +14488,19 @@
                 ]
               },
               {
-                "id": "SqlSideEffectsInspection",
+                "id": "SqlDtInspection",
                 "shortDescription": {
-                  "text": "Statement with side effects"
+                  "text": "Ill-formed date/time literals"
                 },
                 "fullDescription": {
-                  "text": "Reports statements that might lead to modification of a database during a read-only connection. To enable read-only mode for a connection, right-click a data source in the Database tool window (View | Tool Windows | Database) and select Properties. In the Data Sources and Drivers dialog, click the Options tab and select the Read-only checkbox. Example (MySQL): 'CREATE TABLE foo(a INT);\nINSERT INTO foo VALUES (1);' As 'CREATE TABLE' and 'INSERT INTO' statements lead to a database modification, these statements will be highlighted in read-only connection mode.",
-                  "markdown": "Reports statements that might lead to modification of a database during a read-only connection.\n\nTo enable read-only mode for a\nconnection,\nright-click a data source in the **Database** tool window (**View \\| Tool Windows \\| Database** ) and select **Properties** .\nIn the **Data Sources and Drivers** dialog, click the **Options** tab and select the **Read-only** checkbox.\n\nExample (MySQL):\n\n    CREATE TABLE foo(a INT);\n    INSERT INTO foo VALUES (1);\n\nAs `CREATE TABLE` and `INSERT INTO` statements lead to a database modification, these statements will be highlighted\nin read-only connection mode."
+                  "text": "Reports errors in date and time literals. This inspection is available in MySQL, Oracle, Db2, and H2. Example (MySQL): 'SELECT TIME '10 -12:13:14' FROM dual;\nSELECT TIME ' 12 : 13 : 14 ' FROM dual;\nSELECT TIME '12 13 14' FROM dual;\nSELECT TIME '12-13-14' FROM dual;\nSELECT TIME '12.13.14' FROM dual;\nSELECT TIME '12:13:' FROM dual;\nSELECT TIME '12:13' FROM dual;\nSELECT TIME '12:' FROM dual;' In this example, dates ignore the MySQL standard for date and time literals. Therefore, they will be highlighted. For more information about date and time literals in MySQL, see Date and Time Literals at dev.mysql.com. The following date and type literals are valid for MySQL. 'SELECT TIME '12:13:14' FROM dual;\nSELECT TIME '12:13:14.555' FROM dual;\nSELECT TIME '12:13:14.' FROM dual;\nSELECT TIME '-12:13:14' FROM dual;\nSELECT TIME '10 12:13:14' FROM dual;\nSELECT TIME '-10 12:13:14' FROM dual;'",
+                  "markdown": "Reports errors in date and time literals. This inspection is available in MySQL, Oracle, Db2, and H2.\n\nExample (MySQL):\n\n    SELECT TIME '10 -12:13:14' FROM dual;\n    SELECT TIME ' 12 : 13 : 14 ' FROM dual;\n    SELECT TIME '12 13 14' FROM dual;\n    SELECT TIME '12-13-14' FROM dual;\n    SELECT TIME '12.13.14' FROM dual;\n    SELECT TIME '12:13:' FROM dual;\n    SELECT TIME '12:13' FROM dual;\n    SELECT TIME '12:' FROM dual;\n\nIn this example, dates ignore the MySQL standard for date and time literals. Therefore, they will be highlighted.\nFor more information about date and time literals in MySQL, see [Date and Time Literals at dev.mysql.com](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-literals.html).\n\nThe following date and type literals are valid for MySQL.\n\n    SELECT TIME '12:13:14' FROM dual;\n    SELECT TIME '12:13:14.555' FROM dual;\n    SELECT TIME '12:13:14.' FROM dual;\n    SELECT TIME '-12:13:14' FROM dual;\n    SELECT TIME '10 12:13:14' FROM dual;\n    SELECT TIME '-10 12:13:14' FROM dual;\n"
                 },
                 "defaultConfiguration": {
                   "enabled": false,
                   "level": "warning",
                   "parameters": {
-                    "suppressToolId": "SqlSideEffects",
+                    "suppressToolId": "SqlDateTime",
                     "ideaSeverity": "WARNING",
                     "qodanaSeverity": "High"
                   }
@@ -14521,19 +14521,19 @@
                 ]
               },
               {
-                "id": "SqlDtInspection",
+                "id": "SqlSideEffectsInspection",
                 "shortDescription": {
-                  "text": "Ill-formed date/time literals"
+                  "text": "Statement with side effects"
                 },
                 "fullDescription": {
-                  "text": "Reports errors in date and time literals. This inspection is available in MySQL, Oracle, Db2, and H2. Example (MySQL): 'SELECT TIME '10 -12:13:14' FROM dual;\nSELECT TIME ' 12 : 13 : 14 ' FROM dual;\nSELECT TIME '12 13 14' FROM dual;\nSELECT TIME '12-13-14' FROM dual;\nSELECT TIME '12.13.14' FROM dual;\nSELECT TIME '12:13:' FROM dual;\nSELECT TIME '12:13' FROM dual;\nSELECT TIME '12:' FROM dual;' In this example, dates ignore the MySQL standard for date and time literals. Therefore, they will be highlighted. For more information about date and time literals in MySQL, see Date and Time Literals at dev.mysql.com. The following date and type literals are valid for MySQL. 'SELECT TIME '12:13:14' FROM dual;\nSELECT TIME '12:13:14.555' FROM dual;\nSELECT TIME '12:13:14.' FROM dual;\nSELECT TIME '-12:13:14' FROM dual;\nSELECT TIME '10 12:13:14' FROM dual;\nSELECT TIME '-10 12:13:14' FROM dual;'",
-                  "markdown": "Reports errors in date and time literals. This inspection is available in MySQL, Oracle, Db2, and H2.\n\nExample (MySQL):\n\n    SELECT TIME '10 -12:13:14' FROM dual;\n    SELECT TIME ' 12 : 13 : 14 ' FROM dual;\n    SELECT TIME '12 13 14' FROM dual;\n    SELECT TIME '12-13-14' FROM dual;\n    SELECT TIME '12.13.14' FROM dual;\n    SELECT TIME '12:13:' FROM dual;\n    SELECT TIME '12:13' FROM dual;\n    SELECT TIME '12:' FROM dual;\n\nIn this example, dates ignore the MySQL standard for date and time literals. Therefore, they will be highlighted.\nFor more information about date and time literals in MySQL, see [Date and Time Literals at dev.mysql.com](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-literals.html).\n\nThe following date and type literals are valid for MySQL.\n\n    SELECT TIME '12:13:14' FROM dual;\n    SELECT TIME '12:13:14.555' FROM dual;\n    SELECT TIME '12:13:14.' FROM dual;\n    SELECT TIME '-12:13:14' FROM dual;\n    SELECT TIME '10 12:13:14' FROM dual;\n    SELECT TIME '-10 12:13:14' FROM dual;\n"
+                  "text": "Reports statements that might lead to modification of a database during a read-only connection. To enable read-only mode for a connection, right-click a data source in the Database tool window (View | Tool Windows | Database) and select Properties. In the Data Sources and Drivers dialog, click the Options tab and select the Read-only checkbox. Example (MySQL): 'CREATE TABLE foo(a INT);\nINSERT INTO foo VALUES (1);' As 'CREATE TABLE' and 'INSERT INTO' statements lead to a database modification, these statements will be highlighted in read-only connection mode.",
+                  "markdown": "Reports statements that might lead to modification of a database during a read-only connection.\n\nTo enable read-only mode for a\nconnection,\nright-click a data source in the **Database** tool window (**View \\| Tool Windows \\| Database** ) and select **Properties** .\nIn the **Data Sources and Drivers** dialog, click the **Options** tab and select the **Read-only** checkbox.\n\nExample (MySQL):\n\n    CREATE TABLE foo(a INT);\n    INSERT INTO foo VALUES (1);\n\nAs `CREATE TABLE` and `INSERT INTO` statements lead to a database modification, these statements will be highlighted\nin read-only connection mode."
                 },
                 "defaultConfiguration": {
                   "enabled": false,
                   "level": "warning",
                   "parameters": {
-                    "suppressToolId": "SqlDateTime",
+                    "suppressToolId": "SqlSideEffects",
                     "ideaSeverity": "WARNING",
                     "qodanaSeverity": "High"
                   }
@@ -14818,6 +14818,39 @@
                 ]
               },
               {
+                "id": "MysqlParsingInspection",
+                "shortDescription": {
+                  "text": "Unsupported syntax in pre-8.0 versions"
+                },
+                "fullDescription": {
+                  "text": "Reports invalid usages of UNION in queries. The inspection works in MySQL versions that are earlier than 8.0. Example (MySQL): 'SELECT * FROM (SELECT 1 UNION (SELECT 1 UNION SELECT 2)) a;'",
+                  "markdown": "Reports invalid usages of UNION in queries.\n\nThe inspection works in MySQL versions that are earlier than 8.0.\n\nExample (MySQL):\n\n\n    SELECT * FROM (SELECT 1 UNION (SELECT 1 UNION SELECT 2)) a;\n"
+                },
+                "defaultConfiguration": {
+                  "enabled": false,
+                  "level": "warning",
+                  "parameters": {
+                    "suppressToolId": "MysqlParsing",
+                    "ideaSeverity": "WARNING",
+                    "qodanaSeverity": "High"
+                  }
+                },
+                "relationships": [
+                  {
+                    "target": {
+                      "id": "MySQL",
+                      "index": 12,
+                      "toolComponent": {
+                        "name": "QDPY"
+                      }
+                    },
+                    "kinds": [
+                      "superset"
+                    ]
+                  }
+                ]
+              },
+              {
                 "id": "SqlCallNotationInspection",
                 "shortDescription": {
                   "text": "Using of named and positional arguments"
@@ -14840,39 +14873,6 @@
                     "target": {
                       "id": "SQL",
                       "index": 31,
-                      "toolComponent": {
-                        "name": "QDPY"
-                      }
-                    },
-                    "kinds": [
-                      "superset"
-                    ]
-                  }
-                ]
-              },
-              {
-                "id": "MysqlParsingInspection",
-                "shortDescription": {
-                  "text": "Unsupported syntax in pre-8.0 versions"
-                },
-                "fullDescription": {
-                  "text": "Reports invalid usages of UNION in queries. The inspection works in MySQL versions that are earlier than 8.0. Example (MySQL): 'SELECT * FROM (SELECT 1 UNION (SELECT 1 UNION SELECT 2)) a;'",
-                  "markdown": "Reports invalid usages of UNION in queries.\n\nThe inspection works in MySQL versions that are earlier than 8.0.\n\nExample (MySQL):\n\n\n    SELECT * FROM (SELECT 1 UNION (SELECT 1 UNION SELECT 2)) a;\n"
-                },
-                "defaultConfiguration": {
-                  "enabled": false,
-                  "level": "warning",
-                  "parameters": {
-                    "suppressToolId": "MysqlParsing",
-                    "ideaSeverity": "WARNING",
-                    "qodanaSeverity": "High"
-                  }
-                },
-                "relationships": [
-                  {
-                    "target": {
-                      "id": "MySQL",
-                      "index": 13,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -15610,19 +15610,19 @@
                 ]
               },
               {
-                "id": "SqlIdentifierInspection",
+                "id": "SqlRedundantAliasInspection",
                 "shortDescription": {
-                  "text": "Identifier should be quoted"
+                  "text": "Redundant alias expressions"
                 },
                 "fullDescription": {
-                  "text": "Reports situations when you use SQL reserved keywords as identifier names in your query. Example (Microsoft SQL Server): 'CREATE TABLE select (identity INT IDENTITY NOT NULL, order INT NOT NULL);' We use 'select', 'identity', and 'order' as table and column names. But they are also reserved keywords in Microsoft SQL Server. Therefore, in order to use them as object names in the query, you must quote these identifiers. To quote them, you can use the Quote identifier quick-fix. After the quick-fix is applied: 'CREATE TABLE [select] ([identity] INT IDENTITY NOT NULL, [order] INT NOT NULL);'",
-                  "markdown": "Reports situations when you use SQL reserved keywords as identifier names in your query.\n\nExample (Microsoft SQL Server):\n\n    CREATE TABLE select (identity INT IDENTITY NOT NULL, order INT NOT NULL);\n\nWe use `select`, `identity`, and `order` as table and column names.\nBut they are also reserved keywords in Microsoft SQL Server.\nTherefore, in order to use them as object names in the query, you must quote these identifiers. To quote them, you can use the\n**Quote identifier** quick-fix.\n\nAfter the quick-fix is applied:\n\n    CREATE TABLE [select] ([identity] INT IDENTITY NOT NULL, [order] INT NOT NULL);\n"
+                  "text": "Reports alias expressions that duplicate names of columns in tables and might be redundant. Example (PostgreSQL): 'CREATE TABLE foo(a INT, b INT);\n\nSELECT * FROM foo foo(a, b);\nSELECT * FROM foo foo(a);\nSELECT * FROM foo foo(x);\nSELECT * FROM foo foo(x, y);' The first two aliases use the same column names as in the 'foo' table. They are considered redundant because they column names are identical.",
+                  "markdown": "Reports alias expressions that duplicate names of columns in tables and might be redundant.\n\nExample (PostgreSQL):\n\n    CREATE TABLE foo(a INT, b INT);\n\n    SELECT * FROM foo foo(a, b);\n    SELECT * FROM foo foo(a);\n    SELECT * FROM foo foo(x);\n    SELECT * FROM foo foo(x, y);\n\nThe first two aliases use the same column names as in the `foo` table. They are considered redundant because they\ncolumn names are identical."
                 },
                 "defaultConfiguration": {
                   "enabled": false,
                   "level": "warning",
                   "parameters": {
-                    "suppressToolId": "SqlIdentifier",
+                    "suppressToolId": "SqlRedundantAlias",
                     "ideaSeverity": "WARNING",
                     "qodanaSeverity": "High"
                   }
@@ -15643,19 +15643,19 @@
                 ]
               },
               {
-                "id": "SqlRedundantAliasInspection",
+                "id": "SqlIdentifierInspection",
                 "shortDescription": {
-                  "text": "Redundant alias expressions"
+                  "text": "Identifier should be quoted"
                 },
                 "fullDescription": {
-                  "text": "Reports alias expressions that duplicate names of columns in tables and might be redundant. Example (PostgreSQL): 'CREATE TABLE foo(a INT, b INT);\n\nSELECT * FROM foo foo(a, b);\nSELECT * FROM foo foo(a);\nSELECT * FROM foo foo(x);\nSELECT * FROM foo foo(x, y);' The first two aliases use the same column names as in the 'foo' table. They are considered redundant because they column names are identical.",
-                  "markdown": "Reports alias expressions that duplicate names of columns in tables and might be redundant.\n\nExample (PostgreSQL):\n\n    CREATE TABLE foo(a INT, b INT);\n\n    SELECT * FROM foo foo(a, b);\n    SELECT * FROM foo foo(a);\n    SELECT * FROM foo foo(x);\n    SELECT * FROM foo foo(x, y);\n\nThe first two aliases use the same column names as in the `foo` table. They are considered redundant because they\ncolumn names are identical."
+                  "text": "Reports situations when you use SQL reserved keywords as identifier names in your query. Example (Microsoft SQL Server): 'CREATE TABLE select (identity INT IDENTITY NOT NULL, order INT NOT NULL);' We use 'select', 'identity', and 'order' as table and column names. But they are also reserved keywords in Microsoft SQL Server. Therefore, in order to use them as object names in the query, you must quote these identifiers. To quote them, you can use the Quote identifier quick-fix. After the quick-fix is applied: 'CREATE TABLE [select] ([identity] INT IDENTITY NOT NULL, [order] INT NOT NULL);'",
+                  "markdown": "Reports situations when you use SQL reserved keywords as identifier names in your query.\n\nExample (Microsoft SQL Server):\n\n    CREATE TABLE select (identity INT IDENTITY NOT NULL, order INT NOT NULL);\n\nWe use `select`, `identity`, and `order` as table and column names.\nBut they are also reserved keywords in Microsoft SQL Server.\nTherefore, in order to use them as object names in the query, you must quote these identifiers. To quote them, you can use the\n**Quote identifier** quick-fix.\n\nAfter the quick-fix is applied:\n\n    CREATE TABLE [select] ([identity] INT IDENTITY NOT NULL, [order] INT NOT NULL);\n"
                 },
                 "defaultConfiguration": {
                   "enabled": false,
                   "level": "warning",
                   "parameters": {
-                    "suppressToolId": "SqlRedundantAlias",
+                    "suppressToolId": "SqlIdentifier",
                     "ideaSeverity": "WARNING",
                     "qodanaSeverity": "High"
                   }
@@ -16402,7 +16402,7 @@
                   {
                     "target": {
                       "id": "Properties files",
-                      "index": 12,
+                      "index": 13,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -16435,7 +16435,7 @@
                   {
                     "target": {
                       "id": "Properties files",
-                      "index": 12,
+                      "index": 13,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -16468,7 +16468,7 @@
                   {
                     "target": {
                       "id": "Properties files",
-                      "index": 12,
+                      "index": 13,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -16501,7 +16501,7 @@
                   {
                     "target": {
                       "id": "Properties files",
-                      "index": 12,
+                      "index": 13,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -16534,7 +16534,7 @@
                   {
                     "target": {
                       "id": "Properties files",
-                      "index": 12,
+                      "index": 13,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -16567,7 +16567,7 @@
                   {
                     "target": {
                       "id": "Properties files",
-                      "index": 12,
+                      "index": 13,
                       "toolComponent": {
                         "name": "QDPY"
                       }
@@ -19533,7 +19533,7 @@
       },
       "invocations": [
         {
-          "startTimeUtc": "2024-05-26T00:57:33.934920584Z",
+          "startTimeUtc": "2024-06-13T19:58:28.639909247Z",
           "exitCode": 0,
           "executionSuccessful": true
         }
@@ -19541,12 +19541,12 @@
       "language": "en-US",
       "versionControlProvenance": [
         {
-          "revisionId": "4f3c7e12d8d293eef59902b629c121e4cc026988",
+          "revisionId": "76decfc2b9e71be31a151bad4502ce0562b18bd3",
           "properties": {
             "repoUrl": "",
-            "lastAuthorName": "Russell Toris",
+            "lastAuthorName": "Tomás Badenes",
             "vcsType": "Git",
-            "lastAuthorEmail": "russell@inobit.ai"
+            "lastAuthorEmail": "tomasbadenes@gmail.com"
           }
         }
       ],
@@ -21404,62 +21404,6 @@
           "kind": "fail",
           "level": "note",
           "message": {
-            "text": "Package containing module 'socks' is not listed in the project requirements",
-            "markdown": "Package containing module 'socks' is not listed in the project requirements"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 15,
-                  "startColumn": 8,
-                  "charOffset": 370,
-                  "charLength": 5,
-                  "snippet": {
-                    "text": "socks"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 13,
-                  "startColumn": 1,
-                  "charOffset": 307,
-                  "charLength": 96,
-                  "snippet": {
-                    "text": "from PIL import Image\nfrom urllib.parse import urlsplit\nimport socks\nimport ssl\nimport threading"
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v1": "3a0224f30511bad3ebb64f022f56c5cd64feb7e569029e0cbb42ce9e2eeea760"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WEAK WARNING",
-            "qodanaSeverity": "Moderate",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyPackageRequirementsInspection",
-          "kind": "fail",
-          "level": "note",
-          "message": {
             "text": "Package containing module 'pytest' is not listed in the project requirements",
             "markdown": "Package containing module 'pytest' is not listed in the project requirements"
           },
@@ -21501,62 +21445,6 @@
           ],
           "partialFingerprints": {
             "equalIndicator/v1": "8932efdf678772b876f09f7f1cff5d4aacee34aa1c92a5da83eefaa3dc933272"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WEAK WARNING",
-            "qodanaSeverity": "Moderate",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyPackageRequirementsInspection",
-          "kind": "fail",
-          "level": "note",
-          "message": {
-            "text": "Package containing module 'yaml' is not listed in the project requirements",
-            "markdown": "Package containing module 'yaml' is not listed in the project requirements"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 18,
-                  "startColumn": 8,
-                  "charOffset": 411,
-                  "charLength": 4,
-                  "snippet": {
-                    "text": "yaml"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 16,
-                  "startColumn": 1,
-                  "charOffset": 376,
-                  "charLength": 79,
-                  "snippet": {
-                    "text": "import ssl\nimport threading\nimport yaml\n\nfrom inorbit_edge.inorbit_pb2 import ("
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v1": "a30269300f99ac2f191844178f3ad9dceaf1fb0c75da8617a64e24d4cf1f70a4"
           },
           "baselineState": "unchanged",
           "properties": {
@@ -22688,747 +22576,6 @@
           }
         },
         {
-          "ruleId": "PyArgumentListInspection",
-          "kind": "fail",
-          "level": "warning",
-          "message": {
-            "text": "Unexpected argument(s). Possible callees: RobotSession._handle_initial_pose(msg: {decode}) RobotSession._handle_custom_command(msg) RobotSession._handle_custom_message(msg) RobotSession._handle_nav_goal(msg: {decode}) RobotSession._handle_in_cmd(msg: {decode})",
-            "markdown": "Unexpected argument(s). Possible callees: RobotSession._handle_initial_pose(msg: {decode}) RobotSession._handle_custom_command(msg) RobotSession._handle_custom_message(msg) RobotSession._handle_nav_goal(msg: {decode}) RobotSession._handle_in_cmd(msg: {decode})"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 386,
-                  "startColumn": 48,
-                  "charOffset": 14408,
-                  "charLength": 13,
-                  "snippet": {
-                    "text": "(msg.payload)"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 384,
-                  "startColumn": 1,
-                  "charOffset": 14253,
-                  "charLength": 240,
-                  "snippet": {
-                    "text": "            subtopic = \"/\".join(msg.topic.split(\"/\")[2:])\n            if subtopic in self.message_handlers:\n                self.message_handlers[subtopic](msg.payload)\n        except UnicodeDecodeError as ex:\n            self.logger.error("
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v2": "1b3f0fdcb9175fe1",
-            "equalIndicator/v1": "984848252527cca3fab9c87b39ed1a80b71ef8b8a63d914337b950bab2832705"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WARNING",
-            "qodanaSeverity": "High",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyCoverageInspection",
-          "kind": "fail",
-          "level": "warning",
-          "message": {
-            "text": "Method 'register_lasers' coverage is below the threshold 50%",
-            "markdown": "Method `register_lasers` coverage is below the threshold 50%"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 1071,
-                  "startColumn": 9,
-                  "charOffset": 40330,
-                  "charLength": 15,
-                  "snippet": {
-                    "text": "register_lasers"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 1071,
-                  "startColumn": 1,
-                  "charOffset": 40322,
-                  "charLength": 39,
-                  "snippet": {
-                    "text": "    def register_lasers(self, configs):"
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v2": "bdc4d8fe6b110ecc",
-            "equalIndicator/v1": "25347b7e715320b90d7c6057d3da6d6b9ca34943700d8c565ec45b5bf29c6949"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WARNING",
-            "qodanaSeverity": "High",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyCoverageInspection",
-          "kind": "fail",
-          "level": "warning",
-          "message": {
-            "text": "Method 'publish_lasers' coverage is below the threshold 50%",
-            "markdown": "Method `publish_lasers` coverage is below the threshold 50%"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 1001,
-                  "startColumn": 9,
-                  "charOffset": 37450,
-                  "charLength": 14,
-                  "snippet": {
-                    "text": "publish_lasers"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 1001,
-                  "startColumn": 1,
-                  "charOffset": 37442,
-                  "charLength": 73,
-                  "snippet": {
-                    "text": "    def publish_lasers(self, x, y, yaw, ranges, frame_id=\"map\", ts=None):"
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v2": "cf66e6de9f92c0e4",
-            "equalIndicator/v1": "4f0085a48a78808ad2a3a275a46b30ab0c9b28876b9f6b6b40f6815e77b58f96"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WARNING",
-            "qodanaSeverity": "High",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyCoverageInspection",
-          "kind": "fail",
-          "level": "warning",
-          "message": {
-            "text": "Method 'publish_key_values' coverage is below the threshold 50%",
-            "markdown": "Method `publish_key_values` coverage is below the threshold 50%"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 904,
-                  "startColumn": 9,
-                  "charOffset": 33776,
-                  "charLength": 18,
-                  "snippet": {
-                    "text": "publish_key_values"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 904,
-                  "startColumn": 1,
-                  "charOffset": 33768,
-                  "charLength": 79,
-                  "snippet": {
-                    "text": "    def publish_key_values(self, key_values, custom_field=\"0\", is_event=False):"
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v2": "a87e890a3541383f",
-            "equalIndicator/v1": "592677ffe2886eb00c0ee867e359cbfffaf02c336e59b0c7fef2e5ebf5a560a1"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WARNING",
-            "qodanaSeverity": "High",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyCoverageInspection",
-          "kind": "fail",
-          "level": "warning",
-          "message": {
-            "text": "Method 'publish_path' coverage is below the threshold 50%",
-            "markdown": "Method `publish_path` coverage is below the threshold 50%"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 1106,
-                  "startColumn": 9,
-                  "charOffset": 41843,
-                  "charLength": 12,
-                  "snippet": {
-                    "text": "publish_path"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 1106,
-                  "startColumn": 1,
-                  "charOffset": 41835,
-                  "charLength": 78,
-                  "snippet": {
-                    "text": "    def publish_path(self, path_points, path_id=\"0\", frame_id=\"map\", ts=None):"
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v2": "7a7fccbe0ed33822",
-            "equalIndicator/v1": "61ae84a0f61dc1821ff74452368b2babe19a97959c707c64af94770c3a3ef5ae"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WARNING",
-            "qodanaSeverity": "High",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyCoverageInspection",
-          "kind": "fail",
-          "level": "warning",
-          "message": {
-            "text": "Method '_handle_unload_module' coverage is below the threshold 50%",
-            "markdown": "Method `_handle_unload_module` coverage is below the threshold 50%"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 490,
-                  "startColumn": 9,
-                  "charOffset": 18130,
-                  "charLength": 21,
-                  "snippet": {
-                    "text": "_handle_unload_module"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 490,
-                  "startColumn": 1,
-                  "charOffset": 18122,
-                  "charLength": 49,
-                  "snippet": {
-                    "text": "    def _handle_unload_module(self, module_name):"
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v2": "6a199b4b6592bbb4",
-            "equalIndicator/v1": "621ebac94c2ac1b89a9929fafd74342b220bf25646db82f0e88d9e3d84cd8813"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WARNING",
-            "qodanaSeverity": "High",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyCoverageInspection",
-          "kind": "fail",
-          "level": "warning",
-          "message": {
-            "text": "Method 'convert_value' coverage is below the threshold 50%",
-            "markdown": "Method `convert_value` coverage is below the threshold 50%"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 913,
-                  "startColumn": 13,
-                  "charOffset": 34127,
-                  "charLength": 13,
-                  "snippet": {
-                    "text": "convert_value"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 913,
-                  "startColumn": 1,
-                  "charOffset": 34115,
-                  "charLength": 33,
-                  "snippet": {
-                    "text": "        def convert_value(value):"
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v2": "c648f076fdefb1c9",
-            "equalIndicator/v1": "63b0f1ee7ab474a8614b809d2ff1f07e00e721a9f136cdffb19849d40ff89800"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WARNING",
-            "qodanaSeverity": "High",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyCoverageInspection",
-          "kind": "fail",
-          "level": "warning",
-          "message": {
-            "text": "Method 'publish_map' coverage is below the threshold 50%",
-            "markdown": "Method `publish_map` coverage is below the threshold 50%"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 509,
-                  "startColumn": 9,
-                  "charOffset": 18844,
-                  "charLength": 11,
-                  "snippet": {
-                    "text": "publish_map"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 509,
-                  "startColumn": 1,
-                  "charOffset": 18836,
-                  "charLength": 20,
-                  "snippet": {
-                    "text": "    def publish_map("
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v2": "4508be9a56d9560c",
-            "equalIndicator/v1": "86b8c7abc2433a0892e5c9f61247ff70c26d1acc8a7c47d4780af610f9c18238"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WARNING",
-            "qodanaSeverity": "High",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyCoverageInspection",
-          "kind": "fail",
-          "level": "warning",
-          "message": {
-            "text": "Method 'publish_system_stats' coverage is below the threshold 50%",
-            "markdown": "Method `publish_system_stats` coverage is below the threshold 50%"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 937,
-                  "startColumn": 9,
-                  "charOffset": 34861,
-                  "charLength": 20,
-                  "snippet": {
-                    "text": "publish_system_stats"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 937,
-                  "startColumn": 1,
-                  "charOffset": 34853,
-                  "charLength": 29,
-                  "snippet": {
-                    "text": "    def publish_system_stats("
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v2": "1778763056e99a09",
-            "equalIndicator/v1": "a0806bf0f9be73054133e827c15e3ae1d369c7399d95c2ac20a92f09c80306a9"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WARNING",
-            "qodanaSeverity": "High",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyCoverageInspection",
-          "kind": "fail",
-          "level": "warning",
-          "message": {
-            "text": "Method 'publish_odometry' coverage is below the threshold 50%",
-            "markdown": "Method `publish_odometry` coverage is below the threshold 50%"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 964,
-                  "startColumn": 9,
-                  "charOffset": 35980,
-                  "charLength": 16,
-                  "snippet": {
-                    "text": "publish_odometry"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 964,
-                  "startColumn": 1,
-                  "charOffset": 35972,
-                  "charLength": 25,
-                  "snippet": {
-                    "text": "    def publish_odometry("
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v2": "555c75e5c14af283",
-            "equalIndicator/v1": "a0a8f680d0fbf6e8dc7244535b8f40047590cd7731f173eb73c9b383ac6577eb"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WARNING",
-            "qodanaSeverity": "High",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyCoverageInspection",
-          "kind": "fail",
-          "level": "warning",
-          "message": {
-            "text": "Method '_on_disconnect' coverage is below the threshold 50%",
-            "markdown": "Method `_on_disconnect` coverage is below the threshold 50%"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 396,
-                  "startColumn": 9,
-                  "charOffset": 14762,
-                  "charLength": 14,
-                  "snippet": {
-                    "text": "_on_disconnect"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 396,
-                  "startColumn": 1,
-                  "charOffset": 14754,
-                  "charLength": 51,
-                  "snippet": {
-                    "text": "    def _on_disconnect(self, client, userdata, rc):"
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v2": "460d2d268a24b67b",
-            "equalIndicator/v1": "e55b550807445e9bff4e9e24ce23bf0559d8d8062be7dcc0631159d3f6425d83"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WARNING",
-            "qodanaSeverity": "High",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyCoverageInspection",
-          "kind": "fail",
-          "level": "warning",
-          "message": {
-            "text": "Method 'set_pairs' coverage is below the threshold 50%",
-            "markdown": "Method `set_pairs` coverage is below the threshold 50%"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 919,
-                  "startColumn": 13,
-                  "charOffset": 34297,
-                  "charLength": 9,
-                  "snippet": {
-                    "text": "set_pairs"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 919,
-                  "startColumn": 1,
-                  "charOffset": 34285,
-                  "charLength": 25,
-                  "snippet": {
-                    "text": "        def set_pairs(k):"
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v2": "388a2eff8c3f664e",
-            "equalIndicator/v1": "f3718a4b11debd866b265393d441a9e2ac307c5ea7a913c3877b230ea92763ec"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WARNING",
-            "qodanaSeverity": "High",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyCoverageInspection",
-          "kind": "fail",
-          "level": "warning",
-          "message": {
-            "text": "Method 'publish_camera_frame' coverage is below the threshold 50%",
-            "markdown": "Method `publish_camera_frame` coverage is below the threshold 50%"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 566,
-                  "startColumn": 9,
-                  "charOffset": 20736,
-                  "charLength": 20,
-                  "snippet": {
-                    "text": "publish_camera_frame"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 566,
-                  "startColumn": 1,
-                  "charOffset": 20728,
-                  "charLength": 72,
-                  "snippet": {
-                    "text": "    def publish_camera_frame(self, camera_id, image, width, height, ts):"
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v2": "8823cd8ac278dd0c",
-            "equalIndicator/v1": "fe12e97afea693f4612f5951c4e51aae86752313a05915a22bcbb46fab65bcf2"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WARNING",
-            "qodanaSeverity": "High",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
           "ruleId": "PyPackageRequirementsInspection",
           "kind": "fail",
           "level": "note",
@@ -23476,7 +22623,7 @@
             "equalIndicator/v2": "01bdaeeba411b97f",
             "equalIndicator/v1": "0495cfd75e64a26195e2881f3612b91e57c920d5555d27011854aa04b194d51c"
           },
-          "baselineState": "new",
+          "baselineState": "unchanged",
           "properties": {
             "ideaSeverity": "WEAK WARNING",
             "qodanaSeverity": "Moderate",
@@ -23486,12 +22633,12 @@
           }
         },
         {
-          "ruleId": "PyUnusedLocalInspection",
+          "ruleId": "PyArgumentListInspection",
           "kind": "fail",
-          "level": "note",
+          "level": "warning",
           "message": {
-            "text": "Parameter 'output' value is not used",
-            "markdown": "Parameter 'output' value is not used"
+            "text": "Unexpected argument(s). Possible callees: RobotSession._handle_initial_pose(msg: {decode}) RobotSession._handle_custom_command(msg) RobotSession._handle_custom_message(msg) RobotSession._handle_nav_goal(msg: {decode}) RobotSession._handle_in_cmd(msg: {decode})",
+            "markdown": "Unexpected argument(s). Possible callees: RobotSession._handle_initial_pose(msg: {decode}) RobotSession._handle_custom_command(msg) RobotSession._handle_custom_message(msg) RobotSession._handle_nav_goal(msg: {decode}) RobotSession._handle_in_cmd(msg: {decode})"
           },
           "locations": [
             {
@@ -23501,22 +22648,22 @@
                   "uriBaseId": "SRCROOT"
                 },
                 "region": {
-                  "startLine": 585,
-                  "startColumn": 35,
-                  "charOffset": 21541,
-                  "charLength": 6,
+                  "startLine": 416,
+                  "startColumn": 48,
+                  "charOffset": 15487,
+                  "charLength": 13,
                   "snippet": {
-                    "text": "output"
+                    "text": "(msg.payload)"
                   },
                   "sourceLanguage": "Python"
                 },
                 "contextRegion": {
-                  "startLine": 583,
+                  "startLine": 414,
                   "startColumn": 1,
-                  "charOffset": 21448,
-                  "charLength": 134,
+                  "charOffset": 15332,
+                  "charLength": 240,
                   "snippet": {
-                    "text": "\n            # TODO: Implement progress reporting function\n            def progress_function(output, error):\n                return 1\n"
+                    "text": "            subtopic = \"/\".join(msg.topic.split(\"/\")[2:])\n            if subtopic in self.message_handlers:\n                self.message_handlers[subtopic](msg.payload)\n        except UnicodeDecodeError as ex:\n            self.logger.error("
                   },
                   "sourceLanguage": "Python"
                 }
@@ -23530,8 +22677,806 @@
             }
           ],
           "partialFingerprints": {
-            "equalIndicator/v2": "c582a969744cc280",
-            "equalIndicator/v1": "2a2dda7466fff0ef3ab06f566dded533392a9c499e7c39a7c996e8d3f470401b"
+            "equalIndicator/v2": "c7f35dabc0da0f39",
+            "equalIndicator/v1": "2e5249d86affa6376aebc0f741a1afc7732a60441d6f28754682942d851e015e"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyCoverageInspection",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Method '_handle_unload_module' coverage is below the threshold 50%",
+            "markdown": "Method `_handle_unload_module` coverage is below the threshold 50%"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 520,
+                  "startColumn": 9,
+                  "charOffset": 19209,
+                  "charLength": 21,
+                  "snippet": {
+                    "text": "_handle_unload_module"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 520,
+                  "startColumn": 1,
+                  "charOffset": 19201,
+                  "charLength": 49,
+                  "snippet": {
+                    "text": "    def _handle_unload_module(self, module_name):"
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "a12f157810be06f1",
+            "equalIndicator/v1": "0472a4c660d330167170e9ff94683fcfb97a5e9af202ccede931df266f380745"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyCoverageInspection",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Method 'convert_value' coverage is below the threshold 50%",
+            "markdown": "Method `convert_value` coverage is below the threshold 50%"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 943,
+                  "startColumn": 13,
+                  "charOffset": 35206,
+                  "charLength": 13,
+                  "snippet": {
+                    "text": "convert_value"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 943,
+                  "startColumn": 1,
+                  "charOffset": 35194,
+                  "charLength": 33,
+                  "snippet": {
+                    "text": "        def convert_value(value):"
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "ee5fabb2914324a2",
+            "equalIndicator/v1": "11585ca8617d4bd4b9dbdb12491bfde3536a8bb871f0c146ab1b2b0044f0e4a7"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyCoverageInspection",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Method 'publish_odometry' coverage is below the threshold 50%",
+            "markdown": "Method `publish_odometry` coverage is below the threshold 50%"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 994,
+                  "startColumn": 9,
+                  "charOffset": 37059,
+                  "charLength": 16,
+                  "snippet": {
+                    "text": "publish_odometry"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 994,
+                  "startColumn": 1,
+                  "charOffset": 37051,
+                  "charLength": 25,
+                  "snippet": {
+                    "text": "    def publish_odometry("
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "e4d68f497177e540",
+            "equalIndicator/v1": "1180eedcfb1967f6383dbe7b92f1964e69d0f8bed8ad35e279eb5af50ecaecf8"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyCoverageInspection",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Method 'publish_system_stats' coverage is below the threshold 50%",
+            "markdown": "Method `publish_system_stats` coverage is below the threshold 50%"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 967,
+                  "startColumn": 9,
+                  "charOffset": 35940,
+                  "charLength": 20,
+                  "snippet": {
+                    "text": "publish_system_stats"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 967,
+                  "startColumn": 1,
+                  "charOffset": 35932,
+                  "charLength": 29,
+                  "snippet": {
+                    "text": "    def publish_system_stats("
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "8e3a9db078117d5b",
+            "equalIndicator/v1": "26581ef7d98b580cc52115e358ae1d08d826ad3e9f0614d4b7ba949fd8b237db"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyCoverageInspection",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Method 'publish_lasers' coverage is below the threshold 50%",
+            "markdown": "Method `publish_lasers` coverage is below the threshold 50%"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1031,
+                  "startColumn": 9,
+                  "charOffset": 38529,
+                  "charLength": 14,
+                  "snippet": {
+                    "text": "publish_lasers"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 1031,
+                  "startColumn": 1,
+                  "charOffset": 38521,
+                  "charLength": 73,
+                  "snippet": {
+                    "text": "    def publish_lasers(self, x, y, yaw, ranges, frame_id=\"map\", ts=None):"
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "f4e3b43ac222db82",
+            "equalIndicator/v1": "2864725980f88b6707dd516510d66db895613226fbc1b9b106d21c8c8b7fc536"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyCoverageInspection",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Method 'publish_path' coverage is below the threshold 50%",
+            "markdown": "Method `publish_path` coverage is below the threshold 50%"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1136,
+                  "startColumn": 9,
+                  "charOffset": 42922,
+                  "charLength": 12,
+                  "snippet": {
+                    "text": "publish_path"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 1136,
+                  "startColumn": 1,
+                  "charOffset": 42914,
+                  "charLength": 78,
+                  "snippet": {
+                    "text": "    def publish_path(self, path_points, path_id=\"0\", frame_id=\"map\", ts=None):"
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "ca8b2aa87dd3701d",
+            "equalIndicator/v1": "3e42342060567fb8c2d0ae909bfd91dc88bcf984cc50ce5fcaf0b804ca4141ca"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyCoverageInspection",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Method 'publish_map' coverage is below the threshold 50%",
+            "markdown": "Method `publish_map` coverage is below the threshold 50%"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 539,
+                  "startColumn": 9,
+                  "charOffset": 19923,
+                  "charLength": 11,
+                  "snippet": {
+                    "text": "publish_map"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 539,
+                  "startColumn": 1,
+                  "charOffset": 19915,
+                  "charLength": 20,
+                  "snippet": {
+                    "text": "    def publish_map("
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "b799328c1ef66657",
+            "equalIndicator/v1": "440c0a68ef5589809c6c8a437e2511648c6e85123132b4ee5a575baee534061d"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyCoverageInspection",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Method 'publish_camera_frame' coverage is below the threshold 50%",
+            "markdown": "Method `publish_camera_frame` coverage is below the threshold 50%"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 596,
+                  "startColumn": 9,
+                  "charOffset": 21815,
+                  "charLength": 20,
+                  "snippet": {
+                    "text": "publish_camera_frame"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 596,
+                  "startColumn": 1,
+                  "charOffset": 21807,
+                  "charLength": 72,
+                  "snippet": {
+                    "text": "    def publish_camera_frame(self, camera_id, image, width, height, ts):"
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "f68f6c425a8245df",
+            "equalIndicator/v1": "538366a29e60f42975ca3f740057d860a1d9f6523f978d552b323891d72947fd"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyCoverageInspection",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Method '_on_disconnect' coverage is below the threshold 50%",
+            "markdown": "Method `_on_disconnect` coverage is below the threshold 50%"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 426,
+                  "startColumn": 9,
+                  "charOffset": 15841,
+                  "charLength": 14,
+                  "snippet": {
+                    "text": "_on_disconnect"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 426,
+                  "startColumn": 1,
+                  "charOffset": 15833,
+                  "charLength": 51,
+                  "snippet": {
+                    "text": "    def _on_disconnect(self, client, userdata, rc):"
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "82a6d0cd0408dff5",
+            "equalIndicator/v1": "98f2838854ff51d5a3a94f562e970b07baf2a0f2d11feb7f41b37a00364e6d84"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyCoverageInspection",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Method 'publish_key_values' coverage is below the threshold 50%",
+            "markdown": "Method `publish_key_values` coverage is below the threshold 50%"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 934,
+                  "startColumn": 9,
+                  "charOffset": 34855,
+                  "charLength": 18,
+                  "snippet": {
+                    "text": "publish_key_values"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 934,
+                  "startColumn": 1,
+                  "charOffset": 34847,
+                  "charLength": 79,
+                  "snippet": {
+                    "text": "    def publish_key_values(self, key_values, custom_field=\"0\", is_event=False):"
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "61a4afa2a41a52e1",
+            "equalIndicator/v1": "a6b0cab85a05637cb1abc9bf2cdaea0abc43acd14f9cd05f6cca03e0f852bb3f"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyCoverageInspection",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Method 'set_pairs' coverage is below the threshold 50%",
+            "markdown": "Method `set_pairs` coverage is below the threshold 50%"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 949,
+                  "startColumn": 13,
+                  "charOffset": 35376,
+                  "charLength": 9,
+                  "snippet": {
+                    "text": "set_pairs"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 949,
+                  "startColumn": 1,
+                  "charOffset": 35364,
+                  "charLength": 25,
+                  "snippet": {
+                    "text": "        def set_pairs(k):"
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "bbf43ce7555cbba4",
+            "equalIndicator/v1": "c7436a3a8769a96b480f9af01313e05cc4aae100e39492609c782a577511cc9a"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyCoverageInspection",
+          "kind": "fail",
+          "level": "warning",
+          "message": {
+            "text": "Method 'register_lasers' coverage is below the threshold 50%",
+            "markdown": "Method `register_lasers` coverage is below the threshold 50%"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1101,
+                  "startColumn": 9,
+                  "charOffset": 41409,
+                  "charLength": 15,
+                  "snippet": {
+                    "text": "register_lasers"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 1101,
+                  "startColumn": 1,
+                  "charOffset": 41401,
+                  "charLength": 39,
+                  "snippet": {
+                    "text": "    def register_lasers(self, configs):"
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "0fbf8fa33c2799d1",
+            "equalIndicator/v1": "f4d49e903bc0c8f3d97d6b5797f7a8362f7faf42848ab7ece7b725f3a39c5c81"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WARNING",
+            "qodanaSeverity": "High",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyPackageRequirementsInspection",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Package containing module 'pytest' is not listed in the project requirements",
+            "markdown": "Package containing module 'pytest' is not listed in the project requirements"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/tests/test_robot_session.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 4,
+                  "startColumn": 8,
+                  "charOffset": 54,
+                  "charLength": 6,
+                  "snippet": {
+                    "text": "pytest"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 2,
+                  "startColumn": 1,
+                  "charOffset": 22,
+                  "charLength": 70,
+                  "snippet": {
+                    "text": "# -*- coding: utf-8 -*-\n\nimport pytest\nfrom requests import HTTPError\n"
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "d80042043c121b33",
+            "equalIndicator/v1": "0ebe0e49d916da267d90ac279b619443e9d147404496ab8532b362ea8dc10ce0"
+          },
+          "baselineState": "new",
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyPackageRequirementsInspection",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Package containing module 'socks' is not listed in the project requirements",
+            "markdown": "Package containing module 'socks' is not listed in the project requirements"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 15,
+                  "startColumn": 8,
+                  "charOffset": 400,
+                  "charLength": 5,
+                  "snippet": {
+                    "text": "socks"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 13,
+                  "startColumn": 1,
+                  "charOffset": 337,
+                  "charLength": 96,
+                  "snippet": {
+                    "text": "from PIL import Image\nfrom urllib.parse import urlsplit\nimport socks\nimport ssl\nimport threading"
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "e6ea3458b765cb1b",
+            "equalIndicator/v1": "b927f3928d69d8ecc954ae4bc55a55d19906b56ff6c9d4498b11e86688e25d50"
           },
           "baselineState": "unchanged",
           "properties": {
@@ -23543,12 +23488,12 @@
           }
         },
         {
-          "ruleId": "PyUnusedLocalInspection",
+          "ruleId": "PyPackageRequirementsInspection",
           "kind": "fail",
           "level": "note",
           "message": {
-            "text": "Parameter 'client' value is not used",
-            "markdown": "Parameter 'client' value is not used"
+            "text": "Package containing module 'yaml' is not listed in the project requirements",
+            "markdown": "Package containing module 'yaml' is not listed in the project requirements"
           },
           "locations": [
             {
@@ -23558,22 +23503,22 @@
                   "uriBaseId": "SRCROOT"
                 },
                 "region": {
-                  "startLine": 329,
-                  "startColumn": 27,
-                  "charOffset": 12051,
-                  "charLength": 6,
+                  "startLine": 18,
+                  "startColumn": 8,
+                  "charOffset": 441,
+                  "charLength": 4,
                   "snippet": {
-                    "text": "client"
+                    "text": "yaml"
                   },
                   "sourceLanguage": "Python"
                 },
                 "contextRegion": {
-                  "startLine": 327,
+                  "startLine": 16,
                   "startColumn": 1,
-                  "charOffset": 11993,
-                  "charLength": 129,
+                  "charOffset": 406,
+                  "charLength": 79,
                   "snippet": {
-                    "text": "        return response.json()\n\n    def _on_connect(self, client, userdata, flags, rc):\n        \"\"\"MQTT client connect callback.\n"
+                    "text": "import ssl\nimport threading\nimport yaml\n\nfrom inorbit_edge.inorbit_pb2 import ("
                   },
                   "sourceLanguage": "Python"
                 }
@@ -23587,8 +23532,8 @@
             }
           ],
           "partialFingerprints": {
-            "equalIndicator/v2": "dc031ef6a5d87cef",
-            "equalIndicator/v1": "321caee26cb749d604947b4b0303414f7c2d019e952b50adeba547bf54289373"
+            "equalIndicator/v2": "ff4f93b5eb5a9487",
+            "equalIndicator/v1": "e8e81d9f4d1041190321447d7e3142c1e242e605ba6220faea9cde931817763d"
           },
           "baselineState": "unchanged",
           "properties": {
@@ -23615,9 +23560,9 @@
                   "uriBaseId": "SRCROOT"
                 },
                 "region": {
-                  "startLine": 585,
+                  "startLine": 615,
                   "startColumn": 43,
-                  "charOffset": 21549,
+                  "charOffset": 22628,
                   "charLength": 5,
                   "snippet": {
                     "text": "error"
@@ -23625,9 +23570,9 @@
                   "sourceLanguage": "Python"
                 },
                 "contextRegion": {
-                  "startLine": 583,
+                  "startLine": 613,
                   "startColumn": 1,
-                  "charOffset": 21448,
+                  "charOffset": 22527,
                   "charLength": 134,
                   "snippet": {
                     "text": "\n            # TODO: Implement progress reporting function\n            def progress_function(output, error):\n                return 1\n"
@@ -23644,8 +23589,8 @@
             }
           ],
           "partialFingerprints": {
-            "equalIndicator/v2": "327dafb6b42fceef",
-            "equalIndicator/v1": "344dc944204487f3b7aaceafb7f7e91f989594f6fa7977256b2a717f720723a0"
+            "equalIndicator/v2": "642902c5489e7541",
+            "equalIndicator/v1": "00e3762174c1382137cf98e9d634bae2da0106e890ecacc64b8d1f7ca264321f"
           },
           "baselineState": "unchanged",
           "properties": {
@@ -23661,8 +23606,8 @@
           "kind": "fail",
           "level": "note",
           "message": {
-            "text": "Parameter 'userdata' value is not used",
-            "markdown": "Parameter 'userdata' value is not used"
+            "text": "Parameter 'output' value is not used",
+            "markdown": "Parameter 'output' value is not used"
           },
           "locations": [
             {
@@ -23672,19 +23617,76 @@
                   "uriBaseId": "SRCROOT"
                 },
                 "region": {
-                  "startLine": 396,
-                  "startColumn": 38,
-                  "charOffset": 14791,
-                  "charLength": 8,
+                  "startLine": 615,
+                  "startColumn": 35,
+                  "charOffset": 22620,
+                  "charLength": 6,
                   "snippet": {
-                    "text": "userdata"
+                    "text": "output"
                   },
                   "sourceLanguage": "Python"
                 },
                 "contextRegion": {
-                  "startLine": 394,
+                  "startLine": 613,
                   "startColumn": 1,
-                  "charOffset": 14735,
+                  "charOffset": 22527,
+                  "charLength": 134,
+                  "snippet": {
+                    "text": "\n            # TODO: Implement progress reporting function\n            def progress_function(output, error):\n                return 1\n"
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "601f3df2db381804",
+            "equalIndicator/v1": "2b7b19ef738160e72f0f153c4640aa5d8605fd1d9bfc6b90041d25d43c5b030c"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyUnusedLocalInspection",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Parameter 'client' value is not used",
+            "markdown": "Parameter 'client' value is not used"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 426,
+                  "startColumn": 30,
+                  "charOffset": 15862,
+                  "charLength": 6,
+                  "snippet": {
+                    "text": "client"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 424,
+                  "startColumn": 1,
+                  "charOffset": 15814,
                   "charLength": 115,
                   "snippet": {
                     "text": "            raise\n\n    def _on_disconnect(self, client, userdata, rc):\n        \"\"\"MQTT client disconnect callback.\n"
@@ -23701,8 +23703,65 @@
             }
           ],
           "partialFingerprints": {
-            "equalIndicator/v2": "2e101a0e3bc691c0",
-            "equalIndicator/v1": "35f01c9c6208ba6d09b99e096acac807a90c13f1c395db10f4159b211c290919"
+            "equalIndicator/v2": "6e40ff76e0ca4475",
+            "equalIndicator/v1": "4b113f989cabe7e5272c7229fe5af69296c4524bf776c02c0835a4392258731a"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyUnusedLocalInspection",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Parameter 'client' value is not used",
+            "markdown": "Parameter 'client' value is not used"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 359,
+                  "startColumn": 27,
+                  "charOffset": 13130,
+                  "charLength": 6,
+                  "snippet": {
+                    "text": "client"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 357,
+                  "startColumn": 1,
+                  "charOffset": 13072,
+                  "charLength": 129,
+                  "snippet": {
+                    "text": "        return response.json()\n\n    def _on_connect(self, client, userdata, flags, rc):\n        \"\"\"MQTT client connect callback.\n"
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "9ecec7064b0e80c5",
+            "equalIndicator/v1": "584aad961c61422bff15bd4ccdb0bddcd2900066f800688d46b1161a047161bf"
           },
           "baselineState": "unchanged",
           "properties": {
@@ -23729,9 +23788,9 @@
                   "uriBaseId": "SRCROOT"
                 },
                 "region": {
-                  "startLine": 372,
+                  "startLine": 402,
                   "startColumn": 35,
-                  "charOffset": 13824,
+                  "charOffset": 14903,
                   "charLength": 8,
                   "snippet": {
                     "text": "userdata"
@@ -23739,9 +23798,9 @@
                   "sourceLanguage": "Python"
                 },
                 "contextRegion": {
-                  "startLine": 370,
+                  "startLine": 400,
                   "startColumn": 1,
-                  "charOffset": 13758,
+                  "charOffset": 14837,
                   "charLength": 123,
                   "snippet": {
                     "text": "        self._resend_modules()\n\n    def _on_message(self, client, userdata, msg):\n        \"\"\"MQTT client message callback.\n"
@@ -23758,8 +23817,65 @@
             }
           ],
           "partialFingerprints": {
-            "equalIndicator/v2": "2ed9b8b88f6d41e4",
-            "equalIndicator/v1": "5c2d57499ee4b5d49960e08f702e3a43206a6f89a0312f20179ca6c5a7db04fa"
+            "equalIndicator/v2": "7826b34ccf54f083",
+            "equalIndicator/v1": "994ca7ec6d0e6ee8611f3f382e5992eddce045927767ef4ce127d6c7ae24f3f0"
+          },
+          "baselineState": "unchanged",
+          "properties": {
+            "ideaSeverity": "WEAK WARNING",
+            "qodanaSeverity": "Moderate",
+            "tags": [
+              "Python"
+            ]
+          }
+        },
+        {
+          "ruleId": "PyUnusedLocalInspection",
+          "kind": "fail",
+          "level": "note",
+          "message": {
+            "text": "Parameter 'client' value is not used",
+            "markdown": "Parameter 'client' value is not used"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "inorbit_edge/robot.py",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 402,
+                  "startColumn": 27,
+                  "charOffset": 14895,
+                  "charLength": 6,
+                  "snippet": {
+                    "text": "client"
+                  },
+                  "sourceLanguage": "Python"
+                },
+                "contextRegion": {
+                  "startLine": 400,
+                  "startColumn": 1,
+                  "charOffset": 14837,
+                  "charLength": 123,
+                  "snippet": {
+                    "text": "        self._resend_modules()\n\n    def _on_message(self, client, userdata, msg):\n        \"\"\"MQTT client message callback.\n"
+                  },
+                  "sourceLanguage": "Python"
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "project",
+                  "kind": "module"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "equalIndicator/v2": "ea46b6769c2ea718",
+            "equalIndicator/v1": "ba60ab82d414277b78e6266f5474e897fd769a1657a105e2a81efd5c8f6fc7a2"
           },
           "baselineState": "unchanged",
           "properties": {
@@ -23786,9 +23902,9 @@
                   "uriBaseId": "SRCROOT"
                 },
                 "region": {
-                  "startLine": 485,
+                  "startLine": 515,
                   "startColumn": 48,
-                  "charOffset": 17971,
+                  "charOffset": 19050,
                   "charLength": 9,
                   "snippet": {
                     "text": "run_level"
@@ -23796,9 +23912,9 @@
                   "sourceLanguage": "Python"
                 },
                 "contextRegion": {
-                  "startLine": 483,
+                  "startLine": 513,
                   "startColumn": 1,
-                  "charOffset": 17875,
+                  "charOffset": 18954,
                   "charLength": 201,
                   "snippet": {
                     "text": "            self._handle_unload_module(args[1])\n\n    def _handle_load_module(self, module_name, run_level):\n        \"\"\"Handles a load_module command\"\"\"\n        if module_name == INORBIT_MODULE_CAMERAS:"
@@ -23815,8 +23931,8 @@
             }
           ],
           "partialFingerprints": {
-            "equalIndicator/v2": "b7caa585aac6385a",
-            "equalIndicator/v1": "5f5282ad763e4e351edc091214b7df621d3de1c3b4267d718e283b021ef59f8d"
+            "equalIndicator/v2": "a1596b513e760c5e",
+            "equalIndicator/v1": "c6e41265d001336ac3a7be463db6065418816a358379fead923e8406ce963503"
           },
           "baselineState": "unchanged",
           "properties": {
@@ -23843,9 +23959,9 @@
                   "uriBaseId": "SRCROOT"
                 },
                 "region": {
-                  "startLine": 329,
+                  "startLine": 359,
                   "startColumn": 45,
-                  "charOffset": 12069,
+                  "charOffset": 13148,
                   "charLength": 5,
                   "snippet": {
                     "text": "flags"
@@ -23853,9 +23969,9 @@
                   "sourceLanguage": "Python"
                 },
                 "contextRegion": {
-                  "startLine": 327,
+                  "startLine": 357,
                   "startColumn": 1,
-                  "charOffset": 11993,
+                  "charOffset": 13072,
                   "charLength": 129,
                   "snippet": {
                     "text": "        return response.json()\n\n    def _on_connect(self, client, userdata, flags, rc):\n        \"\"\"MQTT client connect callback.\n"
@@ -23872,8 +23988,8 @@
             }
           ],
           "partialFingerprints": {
-            "equalIndicator/v2": "d12f0d1174f02591",
-            "equalIndicator/v1": "629a6cfc8421a37f542d1d29c762f0c18aef1a512ec8d85d76f264200e3dadf1"
+            "equalIndicator/v2": "6fbb3915124cd106",
+            "equalIndicator/v1": "e014a324155254e1f2f16654db8f8381de167cc08ee85a6fa39f213c3240f104"
           },
           "baselineState": "unchanged",
           "properties": {
@@ -23900,9 +24016,9 @@
                   "uriBaseId": "SRCROOT"
                 },
                 "region": {
-                  "startLine": 329,
-                  "startColumn": 35,
-                  "charOffset": 12059,
+                  "startLine": 426,
+                  "startColumn": 38,
+                  "charOffset": 15870,
                   "charLength": 8,
                   "snippet": {
                     "text": "userdata"
@@ -23910,66 +24026,9 @@
                   "sourceLanguage": "Python"
                 },
                 "contextRegion": {
-                  "startLine": 327,
+                  "startLine": 424,
                   "startColumn": 1,
-                  "charOffset": 11993,
-                  "charLength": 129,
-                  "snippet": {
-                    "text": "        return response.json()\n\n    def _on_connect(self, client, userdata, flags, rc):\n        \"\"\"MQTT client connect callback.\n"
-                  },
-                  "sourceLanguage": "Python"
-                }
-              },
-              "logicalLocations": [
-                {
-                  "fullyQualifiedName": "project",
-                  "kind": "module"
-                }
-              ]
-            }
-          ],
-          "partialFingerprints": {
-            "equalIndicator/v2": "3057ea651978600b",
-            "equalIndicator/v1": "8803a97069b26eb71d3f05d0aebdff489bf908715724b90a17f82d9847a5916e"
-          },
-          "baselineState": "unchanged",
-          "properties": {
-            "ideaSeverity": "WEAK WARNING",
-            "qodanaSeverity": "Moderate",
-            "tags": [
-              "Python"
-            ]
-          }
-        },
-        {
-          "ruleId": "PyUnusedLocalInspection",
-          "kind": "fail",
-          "level": "note",
-          "message": {
-            "text": "Parameter 'client' value is not used",
-            "markdown": "Parameter 'client' value is not used"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "inorbit_edge/robot.py",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 396,
-                  "startColumn": 30,
-                  "charOffset": 14783,
-                  "charLength": 6,
-                  "snippet": {
-                    "text": "client"
-                  },
-                  "sourceLanguage": "Python"
-                },
-                "contextRegion": {
-                  "startLine": 394,
-                  "startColumn": 1,
-                  "charOffset": 14735,
+                  "charOffset": 15814,
                   "charLength": 115,
                   "snippet": {
                     "text": "            raise\n\n    def _on_disconnect(self, client, userdata, rc):\n        \"\"\"MQTT client disconnect callback.\n"
@@ -23986,8 +24045,8 @@
             }
           ],
           "partialFingerprints": {
-            "equalIndicator/v2": "777e6e45fe4f1d3e",
-            "equalIndicator/v1": "f925ae045627ef774d2a9ba07797108c884c728ae7562135999c4704496ae9d8"
+            "equalIndicator/v2": "9f3dee40a6f17cdf",
+            "equalIndicator/v1": "e70fecfb31ab0c25c080be96bca1a6974788f57c6f8aed9e1a2336fbed454399"
           },
           "baselineState": "unchanged",
           "properties": {
@@ -24003,8 +24062,8 @@
           "kind": "fail",
           "level": "note",
           "message": {
-            "text": "Parameter 'client' value is not used",
-            "markdown": "Parameter 'client' value is not used"
+            "text": "Parameter 'userdata' value is not used",
+            "markdown": "Parameter 'userdata' value is not used"
           },
           "locations": [
             {
@@ -24014,22 +24073,22 @@
                   "uriBaseId": "SRCROOT"
                 },
                 "region": {
-                  "startLine": 372,
-                  "startColumn": 27,
-                  "charOffset": 13816,
-                  "charLength": 6,
+                  "startLine": 359,
+                  "startColumn": 35,
+                  "charOffset": 13138,
+                  "charLength": 8,
                   "snippet": {
-                    "text": "client"
+                    "text": "userdata"
                   },
                   "sourceLanguage": "Python"
                 },
                 "contextRegion": {
-                  "startLine": 370,
+                  "startLine": 357,
                   "startColumn": 1,
-                  "charOffset": 13758,
-                  "charLength": 123,
+                  "charOffset": 13072,
+                  "charLength": 129,
                   "snippet": {
-                    "text": "        self._resend_modules()\n\n    def _on_message(self, client, userdata, msg):\n        \"\"\"MQTT client message callback.\n"
+                    "text": "        return response.json()\n\n    def _on_connect(self, client, userdata, flags, rc):\n        \"\"\"MQTT client connect callback.\n"
                   },
                   "sourceLanguage": "Python"
                 }
@@ -24043,8 +24102,8 @@
             }
           ],
           "partialFingerprints": {
-            "equalIndicator/v2": "fb8fec522523869e",
-            "equalIndicator/v1": "fdae4ef3c4e4279c8d55d7322398b781239ce895fd586a1a06c3fc68091e07fe"
+            "equalIndicator/v2": "b871ccc6afe8d169",
+            "equalIndicator/v1": "eefa5c6de7bd6464f0e824c61525824ed4a57ca58e74c85449f1b1d01ecd8142"
           },
           "baselineState": "unchanged",
           "properties": {
@@ -24057,10 +24116,10 @@
         }
       ],
       "automationDetails": {
-        "id": "project/qodana/2024-05-26",
-        "guid": "e9ed9109-6880-44cd-9b99-9e535b6978b5",
+        "id": "project/qodana/2024-06-13",
+        "guid": "95d55f4a-30ba-49ca-ad79-9699e57d24f5",
         "properties": {
-          "jobUrl": "https://inorbit.teamcity.com/buildConfiguration/Engineering_Development_DeveloperPortal_EdgeSdkPython_QodanaLinuxQualityCheck/2612"
+          "jobUrl": "https://inorbit.teamcity.com/buildConfiguration/Engineering_Development_DeveloperPortal_EdgeSdkPython_QodanaLinuxQualityCheck/3150"
         }
       },
       "newlineSequences": [
@@ -24070,8 +24129,8 @@
       "properties": {
         "coverage": {
           "totalCoverage": 80,
-          "totalLines": 1431,
-          "totalCoveredLines": 1151
+          "totalLines": 1462,
+          "totalCoveredLines": 1182
         },
         "qodana.sanity.results": [
           {


### PR DESCRIPTION
### Description

Add the method `RobotSession.apply_footprint()` that performs a call to the InOrbit Config API to set a RobotFootprint configuration at the robot level. Requires passing the owner's `account_id` as a keyword argument to `RobotSession`.

The example was updated to show the usage of this method with a custom footprint. The following image shows the result:
![image](https://github.com/inorbit-ai/edge-sdk-python/assets/41840767/93fc1d20-b041-44b5-8e7a-7198167c7556)
