### PR TITLE
Fix: RobotSession parameter `robot_key` mistaken for `robot_api_key`

### DIFF
--- a/inorbit_edge/models.py
+++ b/inorbit_edge/models.py
@@ -89,7 +89,7 @@ class RobotSessionModel(BaseModel):
     Attributes:
         robot_id (str): The unique ID of the robot
         robot_name (str): The name of the robot
-        robot_api_key (str | None, optional): The robot key for InOrbit cloud services
+        robot_key (str | None, optional): The robot key for InOrbit cloud services
         api_key (str | None, optional): The InOrbit API token
         use_ssl (bool, optional): If SSL is used for the InOrbit API connection
         endpoint (HttpUrl, optional): The URL of the API or inorbit_edge's
@@ -98,7 +98,7 @@ class RobotSessionModel(BaseModel):
 
     robot_id: str
     robot_name: str
-    robot_api_key: Optional[str] = None
+    robot_key: Optional[str] = None
     api_key: Optional[str] = os.getenv("INORBIT_API_KEY")
     use_ssl: bool = os.environ.get("INORBIT_USE_SSL", "true").lower() == "true"
     endpoint: HttpUrl = os.environ.get(
@@ -106,11 +106,11 @@ class RobotSessionModel(BaseModel):
     )
 
     # noinspection PyMethodParameters
-    @field_validator("robot_id", "robot_name", "robot_api_key", "api_key")
+    @field_validator("robot_id", "robot_name", "robot_key", "api_key")
     def check_whitespace(cls, value: str) -> str:
         """Check if the field contains whitespace.
 
-        This is used for the robot_id, robot_name, robot_api_key, and api_key.
+        This is used for the robot_id, robot_name, robot_key, and api_key.
 
         Args:
             value (str): The field to be checked

--- a/inorbit_edge/tests/test_models.py
+++ b/inorbit_edge/tests/test_models.py
@@ -94,7 +94,7 @@ class TestRobotSessionModel:
         return {
             "robot_id": "123",
             "robot_name": "test_robot",
-            "robot_api_key": "valid_robot_api_key",
+            "robot_key": "valid_robot_key",
             "api_key": "valid_api_key",
         }
 
@@ -102,7 +102,7 @@ class TestRobotSessionModel:
         model = RobotSessionModel(**base_model)
         assert model.robot_id == base_model["robot_id"]
         assert model.robot_name == base_model["robot_name"]
-        assert model.robot_api_key == base_model["robot_api_key"]
+        assert model.robot_key == base_model["robot_key"]
         assert model.api_key == base_model["api_key"]
         assert model.use_ssl is True
         assert str(model.endpoint) == INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
@@ -117,8 +117,8 @@ class TestRobotSessionModel:
         with pytest.raises(ValidationError, match=r"Whitespaces are not allowed"):
             RobotSessionModel(**base_model)
 
-    def test_whitespace_validation_robot_api_key(self, base_model):
-        base_model["robot_api_key"] = "abc def"
+    def test_whitespace_validation_robot_key(self, base_model):
+        base_model["robot_key"] = "abc def"
         with pytest.raises(ValidationError, match=r"Whitespaces are not allowed"):
             RobotSessionModel(**base_model)
 
@@ -136,7 +136,7 @@ class TestRobotSessionModel:
         init_input = {
             "robot_id": "123",
             "robot_name": "test_robot",
-            "robot_api_key": "valid_robot_api_key",
+            "robot_key": "valid_robot_key",
         }
         model = RobotSessionModel(**init_input)
         assert model.api_key == "env_valid_key"
@@ -150,7 +150,7 @@ class TestRobotSessionModel:
         init_input = {
             "robot_id": "123",
             "robot_name": "test_robot",
-            "robot_api_key": "valid_robot_api_key",
+            "robot_key": "valid_robot_key",
         }
         model = RobotSessionModel(**init_input)
         assert model.use_ssl is False


### PR DESCRIPTION
### Description

`RobotSession` takes a keyword argument `robot_key`, which is used for deploying InOrbit Connect certified robots. `RobotSessionModel` was instead storing a `robot_api_key` which is not read as an constructor argument by `RobotSession`.

`robot_key` argument:
https://github.com/inorbit-ai/edge-sdk-python/blob/88efd145c0fb11aa53615ae320fb5856bc22e564/inorbit_edge/robot.py#L125

Model using `robot_api_key` instead:
https://github.com/inorbit-ai/edge-sdk-python/blob/88efd145c0fb11aa53615ae320fb5856bc22e564/inorbit_edge/models.py#L101

There is a `robot_api_key` variable in RobotSession that serves a different purpose, used for storing credentials retrieved from the SDK cloud config endpoint in [`RobotSession._fetch_robot_config()`](https://github.com/inorbit-ai/edge-sdk-python/blob/88efd145c0fb11aa53615ae320fb5856bc22e564/inorbit_edge/robot.py#L305-L327), See this [unit test](https://github.com/inorbit-ai/edge-sdk-python/blob/35a5868078bd1a3972f7f424a0c53e4a70e73a6d/inorbit_edge/tests/test_robot_session.py#L65-L89) for reference

This PR fixes the error in `RobotSession` and corrects its unit tests.