### PR TITLE
Path downsampling

### DIFF
--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -1279,13 +1279,19 @@ class RobotSession:
                     retain=True,
                 )
 
-    def publish_path(self, path_points, path_id="0", frame_id="map", ts=None):
+    def publish_path(
+        self, path_points, path_id="0", frame_id="map", ts=None, rdp_epsilon=0.001
+    ):
         """Publish robot path
 
         Send a list of points representing the path the robot
         is traversing. This method only sends the data to InOrbit
         for displaying purposes, meaning that the path provided
-        here won't make the robot to move
+        here won't make the robot to move.
+
+        If the provided path is longer than ROBOT_PATH_POINTS_LIMIT points,
+        it will be downsampled using the Ramer-Douglas-Peucker algorithm with the
+        provided epsilon.
 
         Args:
             path_points (List[Tuple[int. int]]): List of x, y points
@@ -1293,6 +1299,9 @@ class RobotSession:
             path_id (str, optional):
             frame_id (str, optional): Robot map frame identifier. Defaults to "map".
             ts (int, optional): Pose timestamp. Defaults to int(time() * 1000).
+            rdp_epsilon (float, optional): epsilon value for the RDP downsampling.
+                Defaults to 0.001. Change only if the downsampling appears too
+                aggressive.
         """
 
         if not self._should_publish_message(method="publish_path"):
@@ -1300,11 +1309,13 @@ class RobotSession:
 
         if len(path_points) > ROBOT_PATH_POINTS_LIMIT:
             self.logger.debug(
-                "Path has {} points. Intelligently downsampling to {} points.".format(
-                    len(path_points), ROBOT_PATH_POINTS_LIMIT
-                )
+                "Path has {} points. Intelligently downsampling to a maximum of {} "
+                "points.".format(len(path_points), ROBOT_PATH_POINTS_LIMIT)
             )
-            path_points = reduce_path(path_points, ROBOT_PATH_POINTS_LIMIT)
+            path_points = reduce_path(path_points, ROBOT_PATH_POINTS_LIMIT, rdp_epsilon)
+            self.logger.debug(
+                "Downsampled path has {} points.".format(len(path_points))
+            )
 
         # Generate ``PathPoint`` protobuf messages
         # from the list of path point tuples

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -46,7 +46,7 @@ from inorbit_edge.commands import (
 import time
 import requests
 import math
-from inorbit_edge.utils import encode_floating_point_list
+from inorbit_edge.utils import encode_floating_point_list, reduce_path
 import certifi
 import subprocess
 import re
@@ -1299,11 +1299,12 @@ class RobotSession:
             return None
 
         if len(path_points) > ROBOT_PATH_POINTS_LIMIT:
-            self.logger.warning(
-                "Path has {} points. Only the first {} points will be used.".format(
+            self.logger.debug(
+                "Path has {} points. Intelligently downsampling to {} points.".format(
                     len(path_points), ROBOT_PATH_POINTS_LIMIT
                 )
             )
+            path_points = reduce_path(path_points, ROBOT_PATH_POINTS_LIMIT)
 
         # Generate ``PathPoint`` protobuf messages
         # from the list of path point tuples

--- a/inorbit_edge/utils.py
+++ b/inorbit_edge/utils.py
@@ -47,9 +47,7 @@ def encode_floating_point_list(ranges):
     return runs, values
 
 
-def reduce_path(
-    path: list[tuple[float, float]], maxn: int
-) -> list[tuple[float, float]]:
+def reduce_path(path: list, maxn: int) -> list:
     """
     Applies the Ramer-Douglas-Peucker algorithm to reduce the number of points in a
     path.

--- a/inorbit_edge/utils.py
+++ b/inorbit_edge/utils.py
@@ -1,4 +1,5 @@
 import math
+from rdp2 import rdp
 
 
 def encode_floating_point_list(ranges):
@@ -44,3 +45,51 @@ def encode_floating_point_list(ranges):
         )
 
     return runs, values
+
+
+def reduce_path(
+    path: list[tuple[float, float]], maxn: int
+) -> list[tuple[float, float]]:
+    """
+    Applies the Ramer-Douglas-Peucker algorithm to reduce the number of points in a
+    path.
+    If after compression the number of points is still greater than maxn, remaining
+    points are uniformly downsampled.
+
+    Args:
+        path (list[tuple[float, float]]): List of tuples (x, y) representing points in
+            the path.
+        maxn (int): Maximum number of points in the reduced path.
+
+    Returns:
+        list[tuple[float, float]]: Reduced list of tuples (x, y) representing points in
+            the path.
+    """
+    reduced_path = rdp(path, epsilon=0.01)
+    if len(reduced_path) <= maxn:
+        return reduced_path
+    return downsample_array(reduced_path, maxn)
+
+
+def downsample_array(arr: list, maxn: int) -> list:
+    """
+    Downsamples (any) array to N elements, taking at regular
+    intervals. First and last element are always returned (provided N>=2).
+
+    Args:
+        arr (list): Array to downsample.
+        maxn (int): Maximum number of elements in the downsampled array.
+
+    Returns:
+        list: Downsampled array.
+    """
+    if len(arr) <= maxn or maxn <= 1:
+        # It is assumed that _downsample will return a new array,
+        # so just save the iterators logic but still return a copy
+        return arr[:]
+
+    # Take exactly maxn elements. Select at regular (non-int) intervals
+    # maxn-1 of them, and the last one manually.
+    return [arr[int(float(i * len(arr)) / (maxn - 1))] for i in range(maxn - 1)] + [
+        arr[-1]
+    ]

--- a/inorbit_edge/utils.py
+++ b/inorbit_edge/utils.py
@@ -47,7 +47,7 @@ def encode_floating_point_list(ranges):
     return runs, values
 
 
-def reduce_path(path: list, maxn: int) -> list:
+def reduce_path(path: list, maxn: int, epsilon: float) -> list:
     """
     Applies the Ramer-Douglas-Peucker algorithm to reduce the number of points in a
     path.
@@ -63,7 +63,7 @@ def reduce_path(path: list, maxn: int) -> list:
         list[tuple[float, float]]: Reduced list of tuples (x, y) representing points in
             the path.
     """
-    reduced_path = rdp(path, epsilon=0.01)
+    reduced_path = rdp(path, epsilon=epsilon)
     if len(reduced_path) <= maxn:
         return reduced_path
     return downsample_array(reduced_path, maxn)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pysocks>=1.7,<2.0
 protobuf>=3.20,<4.0
 certifi>=2024.2
 deprecated>=1.2,<2.0
+rdp2==1.1.1


### PR DESCRIPTION
### Description

Implement intelligent path downsampling on `publish_path` for paths longer than the established maximum of 1000 points.
1. First, the [Ramer–Douglas–Peucker](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm) is applied.
2. If the path still exceeds the limit, it downsampled at regular intervals.

### Demo

_Before_: A path 6057 points long is "cropped" and only the first 1000 points are published

![Screenshot from 2025-05-06 17-40-28](https://github.com/user-attachments/assets/121dc83b-5794-4d28-8734-c8b462888650)

_After_: The same path is reduced to 962 points after applying RDP

![image](https://github.com/user-attachments/assets/4b7df0fb-c68f-4767-bb36-d29a90f7e86f)
