### PR TITLE
Avoid publishing the same path over and over again + reduce UT duration

### DIFF
--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -212,6 +212,8 @@ class RobotSession:
         self.endpoint = str(kwargs.get("endpoint", INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL))
         # Track robot's current pose
         self._last_pose = None
+        # Track the last path points
+        self._last_path_points = None
         # Unique names of configs
         self._laser_config_names = []
         # Use SSL by default
@@ -1335,8 +1337,18 @@ class RobotSession:
                 aggressive.
         """
 
+        # TODO: Implement DeltaInt encoding for path points
+
         if not self._should_publish_message(method="publish_path"):
             return None
+
+        # Check if the path is the same as the last one
+        if self._last_path_points == path_points:
+            self.logger.debug("Path is the same as the last one. Skipping.")
+            return None
+
+        # Update the last path points
+        self._last_path_points = path_points
 
         if len(path_points) > ROBOT_PATH_POINTS_LIMIT:
             self.logger.debug(

--- a/inorbit_edge/tests/test_robot_session.py
+++ b/inorbit_edge/tests/test_robot_session.py
@@ -380,3 +380,27 @@ def test_robot_session_publishes_path_data(mock_mqtt_client, mock_inorbit_api):
     assert all(
         isinstance(coord, (int, float)) for point in decoded_points for coord in point
     )
+
+
+def test_robot_session_publishes_path_data_only_if_changed(
+    mock_mqtt_client,
+    mock_inorbit_api,
+):
+    robot_session = RobotSession(
+        robot_id="id_123",
+        robot_name="name_123",
+        api_key="apikey_123",
+    )
+    # Publishes a simple path with 3 points
+    path_points = [
+        (1, 2),
+        (3, 4),
+        (5, 6),
+    ]
+    robot_session.publish_path(path_points, ts=1)
+
+    # Reset throttling state
+    robot_session._publish_throttling["publish_path"]["last_ts"] = 0
+
+    robot_session.publish_path(path_points, ts=1)
+    robot_session.client.publish.assert_called_once()

--- a/inorbit_edge/tests/test_robot_session_callbacks.py
+++ b/inorbit_edge/tests/test_robot_session_callbacks.py
@@ -18,7 +18,8 @@ from inorbit_edge.robot import RobotSession
 from inorbit_edge.tests.utils.helpers import test_robot_session_connect_helper
 
 
-def test_builtin_callbacks(mock_mqtt_client, mock_inorbit_api):
+def test_builtin_callbacks(mock_mqtt_client, mock_inorbit_api, monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda x: None)
     robot_session = RobotSession(
         robot_id="id_123",
         robot_name="name_123",
@@ -38,7 +39,8 @@ def test_builtin_callbacks(mock_mqtt_client, mock_inorbit_api):
     robot_session.client.subscribe.assert_any_call(topic="r/id_123/ros/loc/mapreq")
 
 
-def test_robot_session_register_command_callback(mock_mqtt_client, mock_inorbit_api):
+def test_robot_session_register_command_callback(mock_mqtt_client, mock_inorbit_api, monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda x: None)
     my_command_handler = MagicMock()
     my_command_handler.__name__ = "my_command_handler"
     robot_session = RobotSession(
@@ -72,7 +74,8 @@ def test_robot_session_register_command_callback(mock_mqtt_client, mock_inorbit_
     )
 
 
-def test_robot_session_echo(mocker, mock_mqtt_client, mock_inorbit_api):
+def test_robot_session_echo(mocker, mock_mqtt_client, mock_inorbit_api, monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda x: None)
     def my_command_handler(*_):
         pass
 
@@ -152,8 +155,9 @@ def test_robot_session_echo(mocker, mock_mqtt_client, mock_inorbit_api):
     ],
 )
 def test_robot_session_executes_command_callback_on_message(
-    mock_mqtt_client, mock_inorbit_api, test_input, expected
+    mock_mqtt_client, mock_inorbit_api, monkeypatch, test_input, expected
 ):
+    monkeypatch.setattr("time.sleep", lambda x: None)
     # Mock command handler.
     my_command_handler = MagicMock()
     # Set command handler mock method's name as it's accessed by the RobotSession class
@@ -188,8 +192,9 @@ def test_robot_session_executes_command_callback_on_message(
 
 
 def test_robot_session_executes_commands(
-    mock_mqtt_client, mock_inorbit_api, mock_popen
+    mock_mqtt_client, mock_inorbit_api, mock_popen, monkeypatch
 ):
+    monkeypatch.setattr("time.sleep", lambda x: None)
     robot_session = RobotSession(
         robot_id="id_123",
         robot_name="name_123",
@@ -203,8 +208,9 @@ def test_robot_session_executes_commands(
 
 
 def test_robot_session_handles_map_requests(
-    mock_mqtt_client, mock_inorbit_api, mock_popen
+    mock_mqtt_client, mock_inorbit_api, mock_popen, monkeypatch
 ):
+    monkeypatch.setattr("time.sleep", lambda x: None)
     robot_session = RobotSession(
         robot_id="id_123",
         robot_name="name_123",

--- a/inorbit_edge/tests/test_robot_session_callbacks.py
+++ b/inorbit_edge/tests/test_robot_session_callbacks.py
@@ -39,7 +39,9 @@ def test_builtin_callbacks(mock_mqtt_client, mock_inorbit_api, monkeypatch):
     robot_session.client.subscribe.assert_any_call(topic="r/id_123/ros/loc/mapreq")
 
 
-def test_robot_session_register_command_callback(mock_mqtt_client, mock_inorbit_api, monkeypatch):
+def test_robot_session_register_command_callback(
+    mock_mqtt_client, mock_inorbit_api, monkeypatch
+):
     monkeypatch.setattr("time.sleep", lambda x: None)
     my_command_handler = MagicMock()
     my_command_handler.__name__ = "my_command_handler"
@@ -76,6 +78,7 @@ def test_robot_session_register_command_callback(mock_mqtt_client, mock_inorbit_
 
 def test_robot_session_echo(mocker, mock_mqtt_client, mock_inorbit_api, monkeypatch):
     monkeypatch.setattr("time.sleep", lambda x: None)
+
     def my_command_handler(*_):
         pass
 

--- a/inorbit_edge/tests/test_robot_session_factory.py
+++ b/inorbit_edge/tests/test_robot_session_factory.py
@@ -8,7 +8,8 @@ from inorbit_edge.inorbit_pb2 import CustomScriptCommandMessage
 from inorbit_edge.tests.utils.helpers import test_robot_session_connect_helper
 
 
-def test_robot_factory_build(mock_mqtt_client):
+def test_robot_factory_build(mock_mqtt_client, monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda x: None)
     robot_session_factory = RobotSessionFactory(
         api_key="apikey_123", endpoint="http://myendpoint/"
     )
@@ -63,8 +64,9 @@ def test_robot_factory_build(mock_mqtt_client):
 
 
 def test_built_robot_session_executes_command_callback_on_message(
-    mock_mqtt_client, mock_inorbit_api
+    mock_mqtt_client, mock_inorbit_api, monkeypatch
 ):
+    monkeypatch.setattr("time.sleep", lambda x: None)
     # Mock command handler.
     my_command_handler = MagicMock()
     another_command_handler = MagicMock()
@@ -112,8 +114,9 @@ def _test_command_handler_helper(command_handler):
 
 
 def test_built_robot_session_executes_commands(
-    mock_mqtt_client, mock_inorbit_api, mock_popen
+    mock_mqtt_client, mock_inorbit_api, mock_popen, monkeypatch
 ):
+    monkeypatch.setattr("time.sleep", lambda x: None)
     robot_session_factory = RobotSessionFactory(api_key="apikey_123")
     robot_session_factory.register_commands_path("./user_scripts", r".*\.sh")
 

--- a/inorbit_edge/tests/test_robot_session_pool.py
+++ b/inorbit_edge/tests/test_robot_session_pool.py
@@ -5,7 +5,10 @@ from inorbit_edge.robot import RobotSessionFactory, RobotSessionPool
 import os
 
 
-def test_robot_session_pool_get_session(mock_mqtt_client, mock_inorbit_api):
+def test_robot_session_pool_get_session(
+    mock_mqtt_client, mock_inorbit_api, monkeypatch
+):
+    monkeypatch.setattr("time.sleep", lambda x: None)
     factory = RobotSessionFactory(api_key="apikey_123")
     pool = RobotSessionPool(factory)
 
@@ -25,7 +28,10 @@ def test_robot_session_pool_get_session(mock_mqtt_client, mock_inorbit_api):
 
 # The robot config data (name, robot_key) for the `get_session` method is
 # provided using a config yaml.
-def test_robot_session_pool_get_session_from_yaml(mock_mqtt_client, mock_inorbit_api, monkeypatch):
+def test_robot_session_pool_get_session_from_yaml(
+    mock_mqtt_client, mock_inorbit_api, monkeypatch
+):
+
     monkeypatch.setattr("time.sleep", lambda x: None)
     dirname = os.path.dirname(__file__)
     robot_config_yaml = os.path.join(dirname, "config/robots_config_robot_key.yaml")
@@ -65,7 +71,7 @@ def test_robot_session_pool_free(mock_mqtt_client, mock_inorbit_api, monkeypatch
 
 def test_robot_session_pool_tear_down(mock_mqtt_client, mock_inorbit_api, monkeypatch):
     monkeypatch.setattr("time.sleep", lambda x: None)
-    
+
     factory = RobotSessionFactory(api_key="apikey_123")
     pool = RobotSessionPool(factory)
 

--- a/inorbit_edge/tests/test_robot_session_pool.py
+++ b/inorbit_edge/tests/test_robot_session_pool.py
@@ -25,7 +25,8 @@ def test_robot_session_pool_get_session(mock_mqtt_client, mock_inorbit_api):
 
 # The robot config data (name, robot_key) for the `get_session` method is
 # provided using a config yaml.
-def test_robot_session_pool_get_session_from_yaml(mock_mqtt_client, mock_inorbit_api):
+def test_robot_session_pool_get_session_from_yaml(mock_mqtt_client, mock_inorbit_api, monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda x: None)
     dirname = os.path.dirname(__file__)
     robot_config_yaml = os.path.join(dirname, "config/robots_config_robot_key.yaml")
 
@@ -46,7 +47,8 @@ def test_robot_session_pool_get_session_from_yaml(mock_mqtt_client, mock_inorbit
     )
 
 
-def test_robot_session_pool_free(mock_mqtt_client, mock_inorbit_api):
+def test_robot_session_pool_free(mock_mqtt_client, mock_inorbit_api, monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda x: None)
     factory = RobotSessionFactory(api_key="apikey_123")
     pool = RobotSessionPool(factory)
 
@@ -61,7 +63,9 @@ def test_robot_session_pool_free(mock_mqtt_client, mock_inorbit_api):
     assert all([not pool.has_robot("id_1"), pool.has_robot("id_2")])
 
 
-def test_robot_session_pool_tear_down(mock_mqtt_client, mock_inorbit_api):
+def test_robot_session_pool_tear_down(mock_mqtt_client, mock_inorbit_api, monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda x: None)
+    
     factory = RobotSessionFactory(api_key="apikey_123")
     pool = RobotSessionPool(factory)
 

--- a/inorbit_edge/tests/test_video.py
+++ b/inorbit_edge/tests/test_video.py
@@ -6,7 +6,8 @@ from inorbit_edge.video import OpenCVCamera
 from inorbit_edge.robot import INORBIT_MODULE_CAMERAS
 
 
-def test_robot_session_register_camera(mock_mqtt_client, mock_inorbit_api, mocker):
+def test_robot_session_register_camera(mock_mqtt_client, mock_inorbit_api, mocker, monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda x: None)
     camera_id = "cam0"
     runlevel = 0
 

--- a/inorbit_edge/tests/test_video.py
+++ b/inorbit_edge/tests/test_video.py
@@ -6,7 +6,9 @@ from inorbit_edge.video import OpenCVCamera
 from inorbit_edge.robot import INORBIT_MODULE_CAMERAS
 
 
-def test_robot_session_register_camera(mock_mqtt_client, mock_inorbit_api, mocker, monkeypatch):
+def test_robot_session_register_camera(
+    mock_mqtt_client, mock_inorbit_api, mocker, monkeypatch
+):
     monkeypatch.setattr("time.sleep", lambda x: None)
     camera_id = "cam0"
     runlevel = 0


### PR DESCRIPTION
### Description

- Implemented a check to avoid publishing the same exact path over and over again
- Improved mocking on UT to make them run faster