### PR TITLE
adding basic opentelemetry metrics

### DIFF
--- a/inorbit_edge/metrics.py
+++ b/inorbit_edge/metrics.py
@@ -1,0 +1,85 @@
+# OpenTelemetry Metrics declarations and helper functions
+#
+# This file declares basic metrics for some SDK function calls. Other metrics
+# can be added by connectors to monitor their own operations, following these
+# examples.
+#
+# In all cases, initialization code is necessary to export these metrics.
+# For example, to export metrics from a connector through a Prometheus HTTP
+# endpoint, add the following to your initialization code:
+#
+#   from opentelemetry import metrics
+#   from opentelemetry.exporter.prometheus import PrometheusMetricReader
+#   from opentelemetry.sdk.metrics import MeterProvider
+#   from opentelemetry.sdk.resources import Resource
+#   from prometheus_client import start_http_server
+#
+#   resource = Resource(attributes={"service.name": "my-connector"})
+#   # Note: Do not use "-" in the MetricsReader namefor GCP envs
+#   metric_reader = PrometheusMetricReader("my_connector")
+#   meter_provider = MeterProvider(metric_readers=[metric_reader], resource=resource)
+#   metrics.set_meter_provider(meter_provider)
+#   start_http_server(port=prometheus_port, addr=prometheus_host)
+#
+import functools
+
+from opentelemetry import metrics
+
+meter = metrics.get_meter("inorbit_edge_sdk")
+
+publish_map_counter = meter.create_counter(
+    "calls_publish_map", "1", "number of calls to publish maps"
+)
+publish_camera_frame_counter = meter.create_counter(
+    "calls_publish_camera_frame", "1", "number of calls to publish camera frames"
+)
+publish_pose_counter = meter.create_counter(
+    "calls_publish_pose", "1", "number of calls to publish poses"
+)
+publish_key_values_counter = meter.create_counter(
+    "calls_publish_key_values", "1", "number of calls to publish key-values"
+)
+publish_system_stats_counter = meter.create_counter(
+    "calls_publish_system_stats", "1", "number of calls to publish system stats"
+)
+publish_odometry_counter = meter.create_counter(
+    "calls_publish_odometry", "1", "number of calls to publish odometry"
+)
+publish_laser_counter = meter.create_counter(
+    "calls_publish_lasers", "1", "number of calls to publish laser(s)"
+)
+publish_path_counter = meter.create_counter(
+    "calls_publish_path", "1", "number of calls to publish paths"
+)
+
+
+def with_counter_metric(metric):
+    """
+    Decorator to count the number of calls to a function
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper_decorator(*args, **kwargs):
+            metric.add(1)
+            return func(*args, **kwargs)
+
+        return wrapper_decorator
+
+    return decorator
+
+
+def with_counter_metric_async(metric):
+    """
+    Decorator to count the number of calls to a function
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        async def wrapper_decorator(*args, **kwargs):
+            metric.add(1)
+            return await func(*args, **kwargs)
+
+        return wrapper_decorator
+
+    return decorator

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -7,6 +7,17 @@ from typing import Tuple, Optional, List, Dict
 
 from inorbit_edge import __version__ as inorbit_edge_version
 from inorbit_edge.types import Pose, SpatialTolerance
+from inorbit_edge.metrics import (
+    with_counter_metric,
+    publish_map_counter,
+    publish_camera_frame_counter,
+    publish_pose_counter,
+    publish_key_values_counter,
+    publish_system_stats_counter,
+    publish_odometry_counter,
+    publish_laser_counter,
+    publish_path_counter,
+)
 import os
 import logging
 import paho.mqtt.client as mqtt
@@ -715,6 +726,7 @@ class RobotSession:
             include_pixels=True,
         )
 
+    @with_counter_metric(publish_map_counter)
     def publish_map(
         self,
         file,
@@ -756,6 +768,7 @@ class RobotSession:
             include_pixels=force_upload,
         )
 
+    @with_counter_metric(publish_camera_frame_counter)
     def publish_camera_frame(self, camera_id, image, width, height, ts):
         """Publishes a camera frame"""
         msg = CameraMessage()
@@ -1079,6 +1092,7 @@ class RobotSession:
         )
         self.logger.debug("Return code: {}".format(ret))
 
+    @with_counter_metric(publish_pose_counter)
     def publish_pose(self, x, y, yaw, frame_id="map", ts=None):
         """Publish robot pose
 
@@ -1114,6 +1128,7 @@ class RobotSession:
             <= tolerance.angularRadians
         )
 
+    @with_counter_metric(publish_key_values_counter)
     def publish_key_values(self, key_values, custom_field="0", is_event=False):
         """Publish key value pairs
 
@@ -1147,6 +1162,7 @@ class RobotSession:
 
         self.publish_protobuf(MQTT_SUBTOPIC_CUSTOM_DATA, msg)
 
+    @with_counter_metric(publish_system_stats_counter)
     def publish_system_stats(
         self,
         cpu_load_percentage=None,
@@ -1174,6 +1190,7 @@ class RobotSession:
 
         self.publish_protobuf(MQTT_SUBTOPIC_SYSTEM_STATS, msg)
 
+    @with_counter_metric(publish_odometry_counter)
     def publish_odometry(
         self,
         ts_start=None,
@@ -1211,6 +1228,7 @@ class RobotSession:
         msg.speed_available = True
         self.publish_protobuf(MQTT_SUBTOPIC_ODOMETRY, msg)
 
+    @with_counter_metric(publish_laser_counter)
     def publish_lasers(self, x, y, yaw, ranges, frame_id="map", ts=None):
         """Publish an array of lasers.
 
@@ -1263,6 +1281,7 @@ class RobotSession:
         # Now publish all lasers
         self.publish_protobuf(MQTT_SUBTOPIC_POSE, msg)
 
+    @with_counter_metric(publish_laser_counter)
     def publish_laser(self, x, y, yaw, ranges, frame_id="map", ts=None):
         """Publish a single robot laser scan.
 
@@ -1316,6 +1335,7 @@ class RobotSession:
                     retain=True,
                 )
 
+    @with_counter_metric(publish_path_counter)
     def publish_path(
         self, path_points, path_id="0", frame_id="map", ts=None, rdp_epsilon=0.001
     ):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ protobuf>=3.20,<4.0
 certifi>=2024.2
 deprecated>=1.2,<2.0
 rdp2==1.1.1
+opentelemetry-api==1.36.0
+opentelemetry-sdk==1.36.0


### PR DESCRIPTION
### OpenTelemetry metrics

Adds OpenTelemetry metrics counters for basic SDK function calls. These can be exported in several ways, including Prometheus through a HTTP endpoint scraper.

An example to export these metrics through Prometheus is given in the metrics.py file. This should eventually be copied to the example `inorbit-connector` project and web documentation.