### PR TITLE
Fix Python version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     #  package_dir={"": "src"},
     packages=find_packages(exclude=["tests", "*.tests", "*.tests.*"]),
     platforms=["Linux", "Mac OS-X", "Windows"],
-    python_requires=">=3.10, <=3.13",
+    python_requires=">=3.10, <3.14",
     url=GITHUB_REPO,
     # Do not edit manually, always use bumpversion (see CONTRIBUTING.rst)
     version=VERSION,


### PR DESCRIPTION
### Description

The previous version stated `python_requires=">=3.10, <=3.13",`. Having a closed upper bound is known to cause issues where package managers on the upper bound python version do not recognize the package as compatible.

Currently CI pipelines on other repositories [are failing](https://github.com/inorbit-ai/inorbit-connector-python/actions/runs/17946143488/job/51032912900?pr=26#logs) to install `inorbit-edge` on Python 3.13.

The official python [packaging guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/) recommends "thinking twice" before using an upper bound:

> Think twice before applying an upper bound like requires-python = "<= 3.10" here. [This blog post](https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special) contains some information regarding possible problems.

With the linked blog post explaining why they can be problematic. I think it is OK to leave the upper bound as open `<3.14`, like it used to be before updating python support to 3.13 (`<3.13`, changed in #75 to `<=3.13`)