### PR TITLE
Bump version: 1.23.1 → 1.24.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 commit = true
-current_version = 1.23.1
+current_version = 1.24.0
 tag = true
 
 [bumpversion:file(version):setup.py]

--- a/inorbit_edge/__init__.py
+++ b/inorbit_edge/__init__.py
@@ -6,7 +6,7 @@ __author__ = "InOrbit"
 __email__ = "support@inorbit.ai"
 # Do not edit this string manually, always use bumpversion
 # Details in CONTRIBUTING.md
-__version__ = "1.23.1"
+__version__ = "1.24.0"
 
 
 def get_module_version():

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import os
 from setuptools import find_packages, setup
 
 # Do not edit manually, always use bumpversion (see CONTRIBUTING.rst)
-VERSION = "1.23.1"
+VERSION = "1.24.0"
 
 GITHUB_ORG = "https://github.com/inorbit-ai"
 GITHUB_REPO = f"{GITHUB_ORG}/edge-sdk-python"
@@ -48,7 +48,7 @@ setup(
     ],
     description="InOrbit Edge SDK for Python",
     # Do not edit manually, always use bumpversion (see CONTRIBUTING.rst)
-    download_url=f"{GITHUB_REPO}/archive/refs/tags/v1.23.1.zip",
+    download_url=f"{GITHUB_REPO}/archive/refs/tags/v1.24.0.zip",
     extras_require={
         "video": requirements["video"],
         "dev": requirements["dev"],


### PR DESCRIPTION
## Release v1.24.0

This release removes blocking calls to publish online/offline status and replaces them with non-blocking ones. To mitigate the possibility of missed status updates, it adds the `get_state` protocol handler with callback mechanism to support InOrbit's multi-layer online/offline detection system.

### Changes
- Change blocking _send_robot_status to non-blocking to prevent applications hanging
- Add `set_online_status_callback()` method to `RobotSession` for connectors to provide status logic
- Add `_handle_get_state()` method that responds to InOrbit's `get_state` commands
- Implement callback pattern to allow connectors to override online status determination

### Breaking Changes
None - this is a backward-compatible addition.

### Migration
Connectors can optionally use the new callback mechanism:
```python
robot_session.set_online_status_callback(lambda: my_robot_is_online())
```