### PR TITLE
Run test-and-lint on PRs targeting next

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - next
 
 jobs:
   lint-and-test:


### PR DESCRIPTION
## Summary
- Add `next` to `pull_request.branches` in `test-and-lint.yml` so PRs into `next` get the same lint+test gate as PRs into `main`.
- Mirrors inorbit-ai/inorbit-connector-python#74.