### PR TITLE
Consolidate InOrbit URL env vars

### DIFF
--- a/inorbit_edge/models.py
+++ b/inorbit_edge/models.py
@@ -11,7 +11,10 @@ from typing import Optional
 from pydantic import BaseModel, AnyUrl, field_validator, HttpUrl
 
 # InOrbit
-from inorbit_edge.robot import INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL, INORBIT_REST_API_URL
+from inorbit_edge.robot import (
+    INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL,
+    INORBIT_DEFAULT_REST_API_URL,
+)
 
 
 class CameraConfig(BaseModel):
@@ -85,10 +88,10 @@ class RobotSessionModel(BaseModel):
 
     * INORBIT_API_KEY (required): The InOrbit API key
     * INORBIT_USE_SSL: If SSL should be used (default is true)
-    * INORBIT_API_URL: The URL of the API (default is
+    * INORBIT_CONFIG_URL: The URL of the config/control plane endpoint (default is
         inorbit_edge.robot.INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL)
-    * INORBIT_REST_API_URL: The URL of the InOrbit REST API (default is
-        inorbit_edge.robot.INORBIT_REST_API_URL)
+    * INORBIT_API_URL: The URL of the InOrbit REST API (default is
+        inorbit_edge.robot.INORBIT_DEFAULT_REST_API_URL)
 
     Attributes:
         robot_id (str): The unique ID of the robot
@@ -99,7 +102,7 @@ class RobotSessionModel(BaseModel):
         endpoint (HttpUrl, optional): The URL of the API or inorbit_edge's
                                       INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL by default
         rest_api_endpoint (HttpUrl, optional): The URL of the InOrbit REST API.
-                                               INORBIT_REST_API_URL by default.
+                                               INORBIT_DEFAULT_REST_API_URL by default.
         account_id (str, optional): The account ID of the robot owner. Required for
                                     applying configurations to the robot.
     """
@@ -110,10 +113,10 @@ class RobotSessionModel(BaseModel):
     api_key: Optional[str] = os.getenv("INORBIT_API_KEY")
     use_ssl: bool = os.environ.get("INORBIT_USE_SSL", "true").lower() == "true"
     endpoint: HttpUrl = os.environ.get(
-        "INORBIT_API_URL", INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
+        "INORBIT_CONFIG_URL", INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
     )
     rest_api_endpoint: Optional[HttpUrl] = os.environ.get(
-        "INORBIT_REST_API_URL", INORBIT_REST_API_URL
+        "INORBIT_API_URL", INORBIT_DEFAULT_REST_API_URL
     )
     account_id: Optional[str] = None
 

--- a/inorbit_edge/models.py
+++ b/inorbit_edge/models.py
@@ -88,8 +88,8 @@ class RobotSessionModel(BaseModel):
 
     * INORBIT_API_KEY (required): The InOrbit API key
     * INORBIT_USE_SSL: If SSL should be used (default is true)
-    * INORBIT_CONNECTION_CONFIG_URL: The URL of the config/control plane endpoint (default is
-        inorbit_edge.robot.INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL)
+    * INORBIT_CONNECTION_CONFIG_URL: The URL of the config/control plane endpoint
+        (default is inorbit_edge.robot.INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL)
     * INORBIT_API_URL: The URL of the InOrbit REST API (default is
         inorbit_edge.robot.INORBIT_DEFAULT_REST_API_URL)
 

--- a/inorbit_edge/models.py
+++ b/inorbit_edge/models.py
@@ -88,7 +88,7 @@ class RobotSessionModel(BaseModel):
 
     * INORBIT_API_KEY (required): The InOrbit API key
     * INORBIT_USE_SSL: If SSL should be used (default is true)
-    * INORBIT_CONFIG_URL: The URL of the config/control plane endpoint (default is
+    * INORBIT_CONNECTION_CONFIG_URL: The URL of the config/control plane endpoint (default is
         inorbit_edge.robot.INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL)
     * INORBIT_API_URL: The URL of the InOrbit REST API (default is
         inorbit_edge.robot.INORBIT_DEFAULT_REST_API_URL)
@@ -113,7 +113,7 @@ class RobotSessionModel(BaseModel):
     api_key: Optional[str] = os.getenv("INORBIT_API_KEY")
     use_ssl: bool = os.environ.get("INORBIT_USE_SSL", "true").lower() == "true"
     endpoint: HttpUrl = os.environ.get(
-        "INORBIT_CONFIG_URL", INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
+        "INORBIT_CONNECTION_CONFIG_URL", INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL
     )
     rest_api_endpoint: Optional[HttpUrl] = os.environ.get(
         "INORBIT_API_URL", INORBIT_DEFAULT_REST_API_URL

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -70,7 +70,7 @@ import re
 from deprecated import deprecated
 
 INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL = "https://control.inorbit.ai/cloud_sdk_robot_config"
-INORBIT_REST_API_URL = "https://api.inorbit.ai"
+INORBIT_DEFAULT_REST_API_URL = "https://api.inorbit.ai"
 
 MQTT_SUBTOPIC_POSE = "ros/loc/data2"
 MQTT_SUBTOPIC_PATH = "ros/loc/path"
@@ -315,7 +315,7 @@ class RobotSession:
             endpoint (str): InOrbit URL. Defaults: INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL.
             use_ssl (bool): Configures MQTT client to use SSL. Defaults: True.
             rest_api_endpoint (str): The URL of the InOrbit REST API.
-                Defaults: INORBIT_REST_API_URL.
+                Defaults: INORBIT_DEFAULT_REST_API_URL.
             account_id (str): The account ID of the robot owner. Required for applying
                 configurations to the robot.
             keepalive_secs (int): Keepalive for MQTT connection (seconds). Default: 10.
@@ -350,7 +350,7 @@ class RobotSession:
         self.use_ssl = kwargs.get("use_ssl", True)
         # InOrbit REST API endpoint
         self.inorbit_rest_api_endpoint = kwargs.get(
-            "rest_api_endpoint", INORBIT_REST_API_URL
+            "rest_api_endpoint", INORBIT_DEFAULT_REST_API_URL
         )
         # Account the robot belongs to. Used for REST API calls.
         self.account_id = kwargs.get("account_id")

--- a/inorbit_edge/tests/demo/README.md
+++ b/inorbit_edge/tests/demo/README.md
@@ -14,7 +14,7 @@ cd /path/to/edge-sdk-python
 pip install -e '.[video,telemetry]'
 cd inorbit_edge/tests/demo
 
-export INORBIT_CONFIG_URL="https://control.inorbit.ai"
+export INORBIT_CONNECTION_CONFIG_URL="https://control.inorbit.ai"
 export INORBIT_API_URL="https://api.inorbit.ai"
 export INORBIT_API_KEY="foobar123"
 export INORBIT_ACCOUNT_ID="account123"
@@ -52,7 +52,7 @@ metrics on the host:
 ```bash
 docker run --rm -p 9464:9464 \
   -v "$PWD/inorbit_edge/tests/demo:/demo:ro" \
-  -e INORBIT_CONFIG_URL=... \
+  -e INORBIT_CONNECTION_CONFIG_URL=... \
   -e INORBIT_API_URL=... \
   -e INORBIT_API_KEY=... \
   -e INORBIT_ACCOUNT_ID=... \

--- a/inorbit_edge/tests/demo/README.md
+++ b/inorbit_edge/tests/demo/README.md
@@ -14,7 +14,7 @@ cd /path/to/edge-sdk-python
 pip install -e '.[video,telemetry]'
 cd inorbit_edge/tests/demo
 
-export INORBIT_URL="https://control.inorbit.ai"
+export INORBIT_CONFIG_URL="https://control.inorbit.ai"
 export INORBIT_API_URL="https://api.inorbit.ai"
 export INORBIT_API_KEY="foobar123"
 export INORBIT_ACCOUNT_ID="account123"
@@ -52,7 +52,7 @@ metrics on the host:
 ```bash
 docker run --rm -p 9464:9464 \
   -v "$PWD/inorbit_edge/tests/demo:/demo:ro" \
-  -e INORBIT_URL=... \
+  -e INORBIT_CONFIG_URL=... \
   -e INORBIT_API_URL=... \
   -e INORBIT_API_KEY=... \
   -e INORBIT_ACCOUNT_ID=... \

--- a/inorbit_edge/tests/demo/example.py
+++ b/inorbit_edge/tests/demo/example.py
@@ -206,7 +206,7 @@ def main():
         radius=0.2,
     )
 
-    inorbit_api_endpoint = _required_env("INORBIT_URL")
+    inorbit_api_endpoint = _required_env("INORBIT_CONFIG_URL")
     inorbit_api_url = _required_env("INORBIT_API_URL")
     inorbit_account_id = _required_env("INORBIT_ACCOUNT_ID")
     inorbit_api_key = _required_env("INORBIT_API_KEY")

--- a/inorbit_edge/tests/demo/example.py
+++ b/inorbit_edge/tests/demo/example.py
@@ -206,7 +206,7 @@ def main():
         radius=0.2,
     )
 
-    inorbit_api_endpoint = _required_env("INORBIT_CONFIG_URL")
+    inorbit_api_endpoint = _required_env("INORBIT_CONNECTION_CONFIG_URL")
     inorbit_api_url = _required_env("INORBIT_API_URL")
     inorbit_account_id = _required_env("INORBIT_ACCOUNT_ID")
     inorbit_api_key = _required_env("INORBIT_API_KEY")

--- a/inorbit_edge/tests/test_robot_session.py
+++ b/inorbit_edge/tests/test_robot_session.py
@@ -8,7 +8,7 @@ import pytest
 from requests import HTTPError
 
 from inorbit_edge.robot import RobotSession, RobotFootprintSpec, RobotMap
-from inorbit_edge.robot import INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL, INORBIT_REST_API_URL
+from inorbit_edge.robot import INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL, INORBIT_DEFAULT_REST_API_URL
 from inorbit_edge import get_module_version
 from inorbit_edge.inorbit_pb2 import MapMessage, RobotPath, PathDataMessage, PathPoint
 
@@ -125,7 +125,7 @@ def test_method_throttling(mock_sleep):
 
 def test_apply_footprint(requests_mock, mock_sleep):
     adapter = requests_mock.post(
-        f"{INORBIT_REST_API_URL}/configuration/apply",
+        f"{INORBIT_DEFAULT_REST_API_URL}/configuration/apply",
         json={"operationStatus": "SUCCESS"},
     )
     footprint = RobotFootprintSpec(
@@ -175,7 +175,7 @@ def test_apply_footprint(requests_mock, mock_sleep):
     }
 
     # HTTP error
-    requests_mock.post(f"{INORBIT_REST_API_URL}/configuration/apply", status_code=400)
+    requests_mock.post(f"{INORBIT_DEFAULT_REST_API_URL}/configuration/apply", status_code=400)
     with pytest.raises(HTTPError):
         robot_session.apply_footprint(footprint)
 

--- a/inorbit_edge/tests/test_robot_session.py
+++ b/inorbit_edge/tests/test_robot_session.py
@@ -8,7 +8,10 @@ import pytest
 from requests import HTTPError
 
 from inorbit_edge.robot import RobotSession, RobotFootprintSpec, RobotMap
-from inorbit_edge.robot import INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL, INORBIT_DEFAULT_REST_API_URL
+from inorbit_edge.robot import (
+    INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL,
+    INORBIT_DEFAULT_REST_API_URL,
+)
 from inorbit_edge import get_module_version
 from inorbit_edge.inorbit_pb2 import MapMessage, RobotPath, PathDataMessage, PathPoint
 
@@ -175,7 +178,9 @@ def test_apply_footprint(requests_mock, mock_sleep):
     }
 
     # HTTP error
-    requests_mock.post(f"{INORBIT_DEFAULT_REST_API_URL}/configuration/apply", status_code=400)
+    requests_mock.post(
+        f"{INORBIT_DEFAULT_REST_API_URL}/configuration/apply", status_code=400
+    )
     with pytest.raises(HTTPError):
         robot_session.apply_footprint(footprint)
 


### PR DESCRIPTION
## Summary

`edge-sdk-python` reads two distinct InOrbit endpoints, a robot configuration endpoint and a REST API, but the env vars naming them collide and duplicate. `INORBIT_API_URL` means the configuration endpoint in `inorbit_edge/models.py` but the REST API in the demo example; the REST API also goes by `INORBIT_REST_API_URL` in the model. The same ambiguity repeats in `connector-python` and `edge-executor`, so a shared `.env` cannot serve the full Connect SDK stack.

This PR picks one name per endpoint. Updates to `connector-python` and `edge-executor`) follow.

## Before

| Env Var | File | SDK param | Endpoint |
|---|---|---|---|
| `INORBIT_API_URL` | `inorbit_edge/models.py` | `endpoint` | Configuration |
| `INORBIT_REST_API_URL` | `inorbit_edge/models.py` | `rest_api_endpoint` | REST API |
| `INORBIT_URL` | `tests/demo/example.py` | `endpoint` | Configuration |
| `INORBIT_API_URL` | `tests/demo/example.py` | `rest_api_endpoint` | REST API |

## After

| Env Var | SDK param | Endpoint | Default |
|---|---|---|---|
| `INORBIT_CONNECTION_CONFIG_URL` | `endpoint` | Configuration | `https://control.inorbit.ai/cloud_sdk_robot_config` |
| `INORBIT_API_URL` | `rest_api_endpoint` | REST API | `https://api.inorbit.ai` |

`INORBIT_API_URL` is reused but its meaning in `models.py` flips from configuration to REST API.

## Changes

- `inorbit_edge/models.py`: `endpoint` reads `INORBIT_CONNECTION_CONFIG_URL`; `rest_api_endpoint` reads `INORBIT_API_URL`. Old names not recognized (no fallback).
- `inorbit_edge/robot.py`: module-level default constant renamed from `INORBIT_REST_API_URL` to `INORBIT_DEFAULT_API_URL` so it no longer collides with the env var. Exported `INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL` preserved (`connector-python` imports it).
- `inorbit_edge/tests/demo/example.py` and `README.md`: updated.
- `inorbit_edge/tests/test_robot_session.py`: import updated.

## Migration

- Rename `INORBIT_URL` to `INORBIT_CONNECTION_CONFIG_URL`.
- If you set `INORBIT_API_URL` for the configuration endpoint (matching previous `models.py` behavior), rename it to `INORBIT_CONNECTION_CONFIG_URL`. `INORBIT_API_URL` is now exclusively the REST API.
- Python importers of `inorbit_edge.robot.INORBIT_REST_API_URL` must switch to `INORBIT_DEFAULT_API_URL`.

## Follow-ups

- `connector-python`: mirror the env var rename; add `INORBIT_API_URL` to `rest_api_endpoint` passthrough (currently no env-var way to set the REST endpoint).
- `edge-executor`: replace `INORBIT_URL` and `INORBIT_API_BASE_URL` with the new names.
- Major version bumps across all three repositories.