### PR TITLE
Replace account_id param with lazy fetch from GET /user

### DIFF
--- a/inorbit_edge/models.py
+++ b/inorbit_edge/models.py
@@ -100,8 +100,6 @@ class RobotSessionModel(BaseModel):
                                       INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL by default
         rest_api_endpoint (HttpUrl, optional): The URL of the InOrbit REST API.
                                                INORBIT_REST_API_URL by default.
-        account_id (str, optional): The account ID of the robot owner. Required for
-                                    applying configurations to the robot.
     """
 
     robot_id: str
@@ -115,10 +113,8 @@ class RobotSessionModel(BaseModel):
     rest_api_endpoint: Optional[HttpUrl] = os.environ.get(
         "INORBIT_REST_API_URL", INORBIT_REST_API_URL
     )
-    account_id: Optional[str] = None
-
     # noinspection PyMethodParameters
-    @field_validator("robot_id", "robot_name", "robot_key", "api_key", "account_id")
+    @field_validator("robot_id", "robot_name", "robot_key", "api_key")
     def check_whitespace(cls, value: str) -> str:
         """Check if the field contains whitespace.
 

--- a/inorbit_edge/models.py
+++ b/inorbit_edge/models.py
@@ -113,6 +113,7 @@ class RobotSessionModel(BaseModel):
     rest_api_endpoint: Optional[HttpUrl] = os.environ.get(
         "INORBIT_REST_API_URL", INORBIT_REST_API_URL
     )
+
     # noinspection PyMethodParameters
     @field_validator("robot_id", "robot_name", "robot_key", "api_key")
     def check_whitespace(cls, value: str) -> str:

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -1669,8 +1669,7 @@ class RobotSession:
         account_ids = response.json().get("accountIds") or []
         if not isinstance(account_ids, list):
             raise ValueError(
-                "Unexpected response from the REST API: "
-                "accountIds is not a list"
+                "Unexpected response from the REST API: " "accountIds is not a list"
             )
         if len(account_ids) == 0:
             raise ValueError("No account IDs found for the authenticated API key")

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -1666,7 +1666,12 @@ class RobotSession:
         )
         response.raise_for_status()
 
-        account_ids = response.json().get("accountIds", [])
+        account_ids = response.json().get("accountIds") or []
+        if not isinstance(account_ids, list):
+            raise ValueError(
+                "Unexpected response from the REST API: "
+                "accountIds is not a list"
+            )
         if len(account_ids) == 0:
             raise ValueError("No account IDs found for the authenticated API key")
         if len(account_ids) > 1:
@@ -1677,7 +1682,7 @@ class RobotSession:
 
         account_id: str = account_ids[0]
         self._account_id = account_id
-        self.logger.info(f"Fetched account ID: {account_id}")
+        self.logger.debug(f"Fetched account ID: {account_id}")
         return account_id
 
     def apply_footprint(self, spec: RobotFootprintSpec):

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -316,8 +316,6 @@ class RobotSession:
             use_ssl (bool): Configures MQTT client to use SSL. Defaults: True.
             rest_api_endpoint (str): The URL of the InOrbit REST API.
                 Defaults: INORBIT_REST_API_URL.
-            account_id (str): The account ID of the robot owner. Required for applying
-                configurations to the robot.
             keepalive_secs (int): Keepalive for MQTT connection (seconds). Default: 10.
             estimate_distance_linear (bool): Whether to publish an estimate value for
                 linear_distance based on poses when the value is not provided on a
@@ -352,8 +350,8 @@ class RobotSession:
         self.inorbit_rest_api_endpoint = kwargs.get(
             "rest_api_endpoint", INORBIT_REST_API_URL
         )
-        # Account the robot belongs to. Used for REST API calls.
-        self.account_id = kwargs.get("account_id")
+        # Account ID, lazily fetched from REST API via get_account_id()
+        self._account_id: str | None = None
 
         # Use TCP transport by default. The client will use websockets
         # transport if the environment variable HTTP_PROXY is set.
@@ -1639,36 +1637,77 @@ class RobotSession:
 
         self.publish_protobuf(MQTT_SUBTOPIC_PATH, msg)
 
+    def get_account_id(self) -> str:
+        """Fetch and cache the account ID from the InOrbit REST API.
+
+        Calls ``GET /user`` using the configured API key. The result is
+        cached so subsequent calls do not make additional HTTP requests.
+
+        Returns:
+            str: The account ID associated with the API key.
+
+        Raises:
+            ValueError: If no ``api_key`` is configured.
+            ValueError: If the API key is associated with zero or multiple accounts.
+            requests.HTTPError: If the REST API request fails.
+        """
+        if self._account_id is not None:
+            return self._account_id
+
+        api_key = self.api_key
+        if not api_key:
+            raise ValueError(
+                "An api_key is required to fetch account info from the REST API"
+            )
+
+        response = requests.get(
+            f"{self.inorbit_rest_api_endpoint}/user",
+            headers={"x-auth-inorbit-app-key": api_key},
+        )
+        response.raise_for_status()
+
+        account_ids = response.json().get("accountIds", [])
+        if len(account_ids) == 0:
+            raise ValueError("No account IDs found for the authenticated API key")
+        if len(account_ids) > 1:
+            raise ValueError(
+                "Multiple account IDs found for the authenticated API key. "
+                "This is not supported by the Edge SDK"
+            )
+
+        account_id: str = account_ids[0]
+        self._account_id = account_id
+        self.logger.info(f"Fetched account ID: {account_id}")
+        return account_id
+
     def apply_footprint(self, spec: RobotFootprintSpec):
         """Creates and applies a RobotFootprint configuration at the robot level scope.
-        Calling this method one time applies a persistent footprint configuration.
-        Note that configurations can be applied at other scopes as well.
-        Refer to the REST APIs documentation for more information.
+
+        Calling this method once applies a persistent footprint configuration.
+        The account ID is fetched automatically from the REST API.
 
         Args:
             spec (RobotFootprintSpec): Robot footprint configuration spec.
-                Will be added to the `spec` field of the RobotFootprint configuration.
 
         Raises:
-            ValueError: If the account ID is not set.
+            ValueError: If no api_key is configured or account cannot be resolved.
             HTTPError: If the request to the InOrbit REST API fails.
-
-        Returns:
-            None
 
         References:
             https://api.inorbit.ai/docs/index.html
         """
+        api_key = self.api_key
+        if not api_key:
+            raise ValueError("An api_key is required to apply footprint configuration")
 
-        if not self.account_id:
-            raise ValueError("Account ID is required to set robot footprint")
+        account_id = self.get_account_id()
 
         body = {
             "apiVersion": "v0.1",
             "kind": "RobotFootprint",
             "metadata": {
                 "id": "all",
-                "scope": f"robot/{self.account_id}/{self.robot_id}",
+                "scope": f"robot/{account_id}/{self.robot_id}",
             },
             "spec": asdict(spec),
         }
@@ -1676,7 +1715,7 @@ class RobotSession:
         res = requests.post(
             f"{self.inorbit_rest_api_endpoint}/configuration/apply",
             json=body,
-            headers={"x-auth-inorbit-app-key": f"{self.api_key}"},
+            headers={"x-auth-inorbit-app-key": api_key},
         )
         res.raise_for_status()
 

--- a/inorbit_edge/tests/demo/Dockerfile
+++ b/inorbit_edge/tests/demo/Dockerfile
@@ -7,7 +7,6 @@
 #     -e INORBIT_URL=... \
 #     -e INORBIT_API_URL=... \
 #     -e INORBIT_API_KEY=... \
-#     -e INORBIT_ACCOUNT_ID=... \
 #     -e INORBIT_USE_SSL=true \
 #     -e INORBIT_ROBOT_ID_PREFIX=$(hostname) \
 #     inorbit-edge-sdk-demo

--- a/inorbit_edge/tests/demo/README.md
+++ b/inorbit_edge/tests/demo/README.md
@@ -17,7 +17,6 @@ cd inorbit_edge/tests/demo
 export INORBIT_URL="https://control.inorbit.ai"
 export INORBIT_API_URL="https://api.inorbit.ai"
 export INORBIT_API_KEY="foobar123"
-export INORBIT_ACCOUNT_ID="account123"
 export INORBIT_ROBOT_ID_PREFIX="$(hostname)"
 # TLS to the MQTT broker defaults to on. For a local broker without TLS: INORBIT_USE_SSL=false
 # Optionally enable video streaming as camera "0"
@@ -55,7 +54,6 @@ docker run --rm -p 9464:9464 \
   -e INORBIT_URL=... \
   -e INORBIT_API_URL=... \
   -e INORBIT_API_KEY=... \
-  -e INORBIT_ACCOUNT_ID=... \
   -e INORBIT_ROBOT_ID_PREFIX=$(hostname) \
   inorbit-edge-sdk-demo
 ```

--- a/inorbit_edge/tests/demo/example.py
+++ b/inorbit_edge/tests/demo/example.py
@@ -208,7 +208,6 @@ def main():
 
     inorbit_api_endpoint = _required_env("INORBIT_URL")
     inorbit_api_url = _required_env("INORBIT_API_URL")
-    inorbit_account_id = _required_env("INORBIT_ACCOUNT_ID")
     inorbit_api_key = _required_env("INORBIT_API_KEY")
 
     # If configured stream video as if it was a robot camera
@@ -224,7 +223,6 @@ def main():
         rest_api_endpoint=inorbit_api_url,
         api_key=inorbit_api_key,
         use_ssl=_mqtt_use_ssl(),
-        account_id=inorbit_account_id,
     )
     robot_session_factory.register_command_callback(log_command)
     robot_session_factory.register_command_callback(my_command_handler)

--- a/inorbit_edge/tests/test_models.py
+++ b/inorbit_edge/tests/test_models.py
@@ -125,11 +125,6 @@ class TestRobotSessionModel:
         with pytest.raises(ValidationError, match=r"Whitespaces are not allowed"):
             RobotSessionModel(**base_model)
 
-    def test_whitespace_validation_account_id(self, base_model):
-        base_model["account_id"] = "abc def"
-        with pytest.raises(ValidationError, match=r"Whitespaces are not allowed"):
-            RobotSessionModel(**base_model)
-
     @mock.patch.dict(os.environ, {"INORBIT_API_KEY": "env_valid_key"})
     def test_reads_api_key_from_environment_variable(self, base_model):
         # Re-import after Mock

--- a/inorbit_edge/tests/test_robot_session.py
+++ b/inorbit_edge/tests/test_robot_session.py
@@ -184,8 +184,10 @@ def test_get_account_id(requests_mock, mock_sleep):
         api_key="apikey_123",
     )
     assert robot_session.get_account_id() == "account_123"
-    # Second call uses cache (no extra HTTP request)
+    # Second call uses cache -- no extra HTTP request
     assert robot_session.get_account_id() == "account_123"
+    user_requests = [h for h in requests_mock.request_history if "/user" in h.path]
+    assert len(user_requests) == 1
 
 
 def test_get_account_id_no_api_key(mock_sleep):

--- a/inorbit_edge/tests/test_robot_session.py
+++ b/inorbit_edge/tests/test_robot_session.py
@@ -124,6 +124,10 @@ def test_method_throttling(mock_sleep):
 
 
 def test_apply_footprint(requests_mock, mock_sleep):
+    requests_mock.get(
+        f"{INORBIT_REST_API_URL}/user",
+        json={"userId": "user_abc", "name": "Test User", "accountIds": ["account_123"]},
+    )
     adapter = requests_mock.post(
         f"{INORBIT_REST_API_URL}/configuration/apply",
         json={"operationStatus": "SUCCESS"},
@@ -138,21 +142,10 @@ def test_apply_footprint(requests_mock, mock_sleep):
         radius=0.2,
     )
 
-    # Missing account_id
     robot_session = RobotSession(
         robot_id="id_123",
         robot_name="name_123",
         api_key="apikey_123",
-    )
-    with pytest.raises(ValueError):
-        robot_session.apply_footprint(footprint)
-
-    # Successful request
-    robot_session = RobotSession(
-        robot_id="id_123",
-        robot_name="name_123",
-        api_key="apikey_123",
-        account_id="account_123",
     )
     robot_session.apply_footprint(footprint)
     assert adapter.called_once
@@ -174,10 +167,74 @@ def test_apply_footprint(requests_mock, mock_sleep):
         },
     }
 
-    # HTTP error
+    # HTTP error on apply
     requests_mock.post(f"{INORBIT_REST_API_URL}/configuration/apply", status_code=400)
     with pytest.raises(HTTPError):
         robot_session.apply_footprint(footprint)
+
+
+def test_get_account_id(requests_mock, mock_sleep):
+    requests_mock.get(
+        f"{INORBIT_REST_API_URL}/user",
+        json={"userId": "user_abc", "name": "Test User", "accountIds": ["account_123"]},
+    )
+    robot_session = RobotSession(
+        robot_id="id_123",
+        robot_name="name_123",
+        api_key="apikey_123",
+    )
+    assert robot_session.get_account_id() == "account_123"
+    # Second call uses cache (no extra HTTP request)
+    assert robot_session.get_account_id() == "account_123"
+
+
+def test_get_account_id_no_api_key(mock_sleep):
+    robot_session = RobotSession(
+        robot_id="id_123",
+        robot_name="name_123",
+        robot_key="robotkey_123",
+    )
+    with pytest.raises(ValueError, match="api_key is required"):
+        robot_session.get_account_id()
+
+
+def test_get_account_id_empty_accounts(requests_mock, mock_sleep):
+    requests_mock.get(
+        f"{INORBIT_REST_API_URL}/user",
+        json={"userId": "user_abc", "name": "Test User", "accountIds": []},
+    )
+    robot_session = RobotSession(
+        robot_id="id_123",
+        robot_name="name_123",
+        api_key="apikey_123",
+    )
+    with pytest.raises(ValueError, match="No account IDs found"):
+        robot_session.get_account_id()
+
+
+def test_get_account_id_multiple_accounts(requests_mock, mock_sleep):
+    requests_mock.get(
+        f"{INORBIT_REST_API_URL}/user",
+        json={"userId": "user_abc", "name": "Test", "accountIds": ["a1", "a2"]},
+    )
+    robot_session = RobotSession(
+        robot_id="id_123",
+        robot_name="name_123",
+        api_key="apikey_123",
+    )
+    with pytest.raises(ValueError, match="Multiple account IDs"):
+        robot_session.get_account_id()
+
+
+def test_get_account_id_api_error(requests_mock, mock_sleep):
+    requests_mock.get(f"{INORBIT_REST_API_URL}/user", status_code=401)
+    robot_session = RobotSession(
+        robot_id="id_123",
+        robot_name="name_123",
+        api_key="apikey_123",
+    )
+    with pytest.raises(HTTPError):
+        robot_session.get_account_id()
 
 
 def test_robot_map_data():


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *our main*.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description

**Breaking change** -- removes the `account_id` parameter from `RobotSession`, `RobotSessionModel`, and `RobotSessionFactory`.

Instead of requiring users to provide their account ID manually, the SDK now fetches it lazily from the `GET /user` REST API endpoint when needed (e.g. when `apply_footprint()` is called). The result is cached for the lifetime of the session.

A new public method `get_account_id()` is available for dependent libraries that need the account ID for their own config-as-code workflows.

**Changes:**
- `robot.py`: Remove `account_id` kwarg, add `get_account_id()` with caching, update `apply_footprint()` to use it
- `models.py`: Remove `account_id` field and its validator
- `tests/test_robot_session.py`: Rewrite footprint test, add tests for `get_account_id()` (caching, no api_key, empty accounts, multiple accounts, API error)
- `tests/test_models.py`: Remove `account_id` whitespace validation test
- `tests/demo/example.py`: Remove `INORBIT_ACCOUNT_ID` env var usage

**Errors on:**
- Missing `api_key` (required for REST API calls)
- Empty `accountIds` in response
- Multiple `accountIds` in response (ambiguous, not supported)

### Demo

<img width="701" height="335" alt="image" src="https://github.com/user-attachments/assets/82674795-bd73-48e9-8eec-cd64f5e4db39" />
