### PR TITLE
Remove deprecated APIs ahead of v3

### DIFF
--- a/inorbit_edge/metrics.py
+++ b/inorbit_edge/metrics.py
@@ -40,8 +40,6 @@ import inspect
 import logging
 import re
 
-from deprecated import deprecated
-
 logger = logging.getLogger(__name__)
 
 
@@ -302,17 +300,3 @@ def with_counter_metric(metric, attributes=None):
         return sync_wrapper
 
     return decorator
-
-
-@deprecated(
-    version="2.0.2",
-    reason=("use with_counter_metric(), which now auto-detects async functions"),
-)
-def with_counter_metric_async(metric):
-    """Deprecated alias for :func:`with_counter_metric`.
-
-    Prefer ``@with_counter_metric(...)``, which now detects async functions
-    automatically.
-    """
-
-    return with_counter_metric(metric)

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -67,7 +67,6 @@ from inorbit_edge.utils import (
 import certifi
 import subprocess
 import re
-from deprecated import deprecated
 
 INORBIT_CLOUD_SDK_ROBOT_CONFIG_URL = "https://control.inorbit.ai/cloud_sdk_robot_config"
 INORBIT_REST_API_URL = "https://api.inorbit.ai"
@@ -1848,11 +1847,3 @@ class RobotSessionPool:
         sess = self.get_session(robot_id)
         sess.disconnect()
         del self.robot_sessions[robot_id]
-
-    @deprecated(
-        version="1.7.2",
-        reason="use RobotSessionFactory.register_command_callback() instead",
-    )
-    def register_command_callback(self, callback):
-        """Registers a callback to be called when a command is received"""
-        self.robot_session_factory.register_command_callback(callback)

--- a/inorbit_edge/tests/test_metrics.py
+++ b/inorbit_edge/tests/test_metrics.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 import asyncio
-import warnings
 
 import pytest
 
@@ -77,22 +76,6 @@ def test_with_counter_metric_counts_even_when_wrapped_raises():
 
     with pytest.raises(RuntimeError):
         f()
-    assert counter.calls == [(1, {})]
-
-
-def test_with_counter_metric_async_alias_emits_deprecation_warning():
-    counter = _RecordingCounter()
-
-    with warnings.catch_warnings(record=True) as captured:
-        warnings.simplefilter("always")
-
-        @edge_metrics.with_counter_metric_async(counter)
-        async def f():
-            return 1
-
-        asyncio.run(f())
-
-    assert any(issubclass(w.category, DeprecationWarning) for w in captured)
     assert counter.calls == [(1, {})]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ pydantic>=2.6,<3.0
 pysocks>=1.7,<2.0
 protobuf~=5.29.6
 certifi>=2024.2
-deprecated>=1.2,<2.0
 rdp2~=1.1.2


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **next branch** (left side).
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description

Remove two deprecated APIs ahead of the v3 major version bump:

- **`with_counter_metric_async()`** (deprecated v2.0.2) -- replaced by `with_counter_metric()` which auto-detects async functions
- **`RobotSessionPool.register_command_callback()`** (deprecated v1.7.2) -- replaced by `RobotSessionFactory.register_command_callback()`

Also removes the `deprecated` package from `requirements.txt` since it is not used anymore.

**Files changed:**
- `inorbit_edge/metrics.py` -- removed function + import
- `inorbit_edge/robot.py` -- removed method + import
- `inorbit_edge/tests/test_metrics.py` -- removed deprecation warning test + unused import
- `requirements.txt` -- removed `deprecated` dependency