### PR TITLE
Prevent MQTT callback errors from silently killing the network loop thread

### DIFF
--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -314,7 +314,7 @@ class RobotSession:
             use_ssl (bool): Configures MQTT client to use SSL. Defaults: True.
             rest_api_endpoint (str): The URL of the InOrbit REST API.
                 Defaults: INORBIT_DEFAULT_API_URL.
-            keepalive_secs (int): Keepalive for MQTT connection (seconds). Default: 10.
+            keepalive_secs (int): Keepalive for MQTT connection (seconds). Default: 60.
             estimate_distance_linear (bool): Whether to publish an estimate value for
                 linear_distance based on poses when the value is not provided on a
                 publish_odometry() call. Default: True
@@ -355,8 +355,10 @@ class RobotSession:
         # transport if the environment variable HTTP_PROXY is set.
         self.use_websockets = kwargs.get("use_websockets", False)
 
-        # Keepalive for MQTT connection (seconds)
-        self.keepalive_secs = kwargs.get("keepalive_secs", 10)
+        # Keepalive for MQTT connection (seconds). 60s is a non-aggressive
+        # default; a very short keepalive trips spurious "keep alive timeout"
+        # disconnects whenever the network loop thread is briefly busy.
+        self.keepalive_secs = kwargs.get("keepalive_secs", 60)
 
         # Read optional proxy configuration from environment variables
         # We use ``self.http_proxy`` to indicate if proxy configuration should be used.
@@ -408,6 +410,11 @@ class RobotSession:
         self.client.on_connect = self._on_connect
         self.client.on_message = self._on_message
         self.client.on_disconnect = self._on_disconnect
+
+        # Belt-and-suspenders: make paho swallow (not re-raise) any exception
+        # escaping a user callback, so a callback bug can never kill the network
+        # loop thread and silently wedge the session.
+        self.client.suppress_exceptions = True
 
         # Functions to handle incoming MQTT messages.
         # They are mapped by MQTT subtopic e.g.
@@ -638,9 +645,14 @@ class RobotSession:
                 f"Failed to decode message, ignoring. Payload: '{msg.payload}'. {ex}"
             )
         except Exception:
-            # Re-raise any other error
-            self.logger.error("Unexpected error while processing message.")
-            raise
+            # Never re-raise: this callback runs on paho's network loop thread,
+            # and an exception escaping it kills that thread permanently (it is
+            # never restarted, while is_connected() can keep reporting True),
+            # silently wedging the session. Log with traceback and swallow.
+            self.logger.exception(
+                f"Unexpected error while processing message on topic "
+                f"'{getattr(msg, 'topic', None)}', ignoring."
+            )
 
     def _on_disconnect(
         self, client, userdata, disconnect_flags, reason_code, properties

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import functools
 import io
 import json
 import logging
@@ -406,14 +407,24 @@ class RobotSession:
                 proxy_type=socks.HTTP, proxy_addr=proxy_hostname, proxy_port=proxy_port
             )
 
-        # Register MQTT client callbacks
-        self.client.on_connect = self._on_connect
-        self.client.on_message = self._on_message
-        self.client.on_disconnect = self._on_disconnect
+        # Surface paho's internal logs (including the messages it emits when it
+        # swallows a callback exception under suppress_exceptions) through this
+        # session's logger, so they are not lost.
+        self.client.enable_logger(self.logger)
 
-        # Belt-and-suspenders: make paho swallow (not re-raise) any exception
-        # escaping a user callback, so a callback bug can never kill the network
-        # loop thread and silently wedge the session.
+        # Register MQTT client callbacks, each wrapped so an exception is logged
+        # (with traceback) and swallowed rather than propagating onto the paho
+        # network loop thread -- where, by default, it would be re-raised and
+        # kill the thread, silently wedging the session. See _guard_callback.
+        self.client.on_connect = self._guard_callback("on_connect")(self._on_connect)
+        self.client.on_message = self._guard_callback("on_message")(self._on_message)
+        self.client.on_disconnect = self._guard_callback("on_disconnect")(
+            self._on_disconnect
+        )
+
+        # Belt-and-suspenders for any callback path not wrapped above (and future
+        # ones): make paho swallow (not re-raise) any exception escaping a
+        # callback, so a callback bug can never kill the network loop thread.
         self.client.suppress_exceptions = True
 
         # Functions to handle incoming MQTT messages.
@@ -624,6 +635,39 @@ class RobotSession:
         self.client.subscribe(topic=self._get_robot_subtopic(subtopic=MQTT_MAP_REQ))
         # ask server to resend modules, so our state is consistent with the server side
         self._resend_modules()
+
+    def _guard_callback(self, name):
+        """Wrap a paho MQTT callback so an exception is logged (with traceback)
+        and swallowed instead of propagating onto paho's network loop thread.
+
+        paho invokes callbacks on the loop thread and, with
+        ``suppress_exceptions`` False (its default), re-raises anything that
+        escapes them -- which unwinds ``loop_forever`` and kills the thread
+        permanently (it is never restarted, while ``is_connected()`` can keep
+        reporting True), silently wedging the session. This logs through the
+        session's own logger with the callback name and a traceback, so the
+        error is visible rather than merely suppressed.
+
+        Args:
+            name (str): Callback name, used in the log message.
+
+        Returns:
+            A decorator that wraps the callback.
+        """
+
+        def decorate(fn):
+            @functools.wraps(fn)
+            def wrapper(*args, **kwargs):
+                try:
+                    return fn(*args, **kwargs)
+                except Exception:
+                    self.logger.exception(
+                        "Unhandled error in MQTT callback '%s', ignoring.", name
+                    )
+
+            return wrapper
+
+        return decorate
 
     def _on_message(self, client, userdata, msg):
         """MQTT client message callback.

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -692,12 +692,14 @@ class RobotSession:
                 f"Failed to decode message, ignoring. Payload: '{msg.payload}'. {ex}"
             )
         except Exception:
-            # Never re-raise: this callback runs on paho's network loop thread,
-            # and an exception escaping it kills that thread permanently (it is
-            # never restarted, while is_connected() can keep reporting True),
-            # silently wedging the session. Log with traceback and swallow.
+            # A handler (or echo) raised while processing this message. Log it
+            # with the topic for context and keep going. Re-raising is not
+            # needed for loop-thread safety here -- _guard_callback (and, behind
+            # it, suppress_exceptions) already stops a callback exception from
+            # unwinding paho's loop thread. This clause just adds a
+            # message-scoped log and keeps _on_message safe if called unwrapped.
             self.logger.exception(
-                f"Unexpected error while processing message on topic "
+                f"Error processing message on topic "
                 f"'{getattr(msg, 'topic', None)}', ignoring."
             )
 

--- a/inorbit_edge/robot.py
+++ b/inorbit_edge/robot.py
@@ -422,9 +422,12 @@ class RobotSession:
             self._on_disconnect
         )
 
-        # Belt-and-suspenders for any callback path not wrapped above (and future
-        # ones): make paho swallow (not re-raise) any exception escaping a
-        # callback, so a callback bug can never kill the network loop thread.
+        # Belt-and-suspenders: make paho swallow (not re-raise) any exception
+        # escaping a callback, so a callback bug can never kill the network loop
+        # thread. This is the only thing covering callback paths the wrappers
+        # above do NOT -- e.g. QoS>0 publish acks invoking on_publish, callbacks
+        # a consumer sets directly on this client (which is a public attribute),
+        # or any callback added in the future without a guard.
         self.client.suppress_exceptions = True
 
         # Functions to handle incoming MQTT messages.

--- a/inorbit_edge/tests/test_robot_session_callbacks.py
+++ b/inorbit_edge/tests/test_robot_session_callbacks.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import logging
 import os
 import time
 from unittest.mock import ANY, MagicMock
@@ -241,6 +242,34 @@ def test_keepalive_default_is_60_seconds(
         robot_id="id_123", robot_name="name_123", api_key="apikey_123"
     )
     assert robot_session.keepalive_secs == 60
+
+
+def test_callback_guard_logs_and_swallows(
+    mock_mqtt_client, mock_inorbit_api, mock_sleep, caplog
+):
+    """_guard_callback must log (with traceback) and swallow any exception so
+    a callback error never propagates onto paho's network loop thread."""
+    robot_session = RobotSession(
+        robot_id="id_123", robot_name="name_123", api_key="apikey_123"
+    )
+
+    @robot_session._guard_callback("on_connect")
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("callback blew up")
+
+    caplog.set_level(logging.ERROR)
+    boom("client", "userdata")  # must not raise
+
+    assert any("on_connect" in r.getMessage() for r in caplog.records)
+
+
+def test_paho_internal_logging_is_wired(mock_mqtt_client, mock_inorbit_api, mock_sleep):
+    """enable_logger must be called so paho's own callback-exception logs
+    (emitted when suppress_exceptions swallows) are surfaced, not lost."""
+    robot_session = RobotSession(
+        robot_id="id_123", robot_name="name_123", api_key="apikey_123"
+    )
+    robot_session.client.enable_logger.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/inorbit_edge/tests/test_robot_session_callbacks.py
+++ b/inorbit_edge/tests/test_robot_session_callbacks.py
@@ -207,6 +207,42 @@ def test_robot_session_echo(mocker, mock_mqtt_client, mock_inorbit_api, mock_sle
     )
 
 
+def test_on_message_handler_error_does_not_propagate(
+    mock_mqtt_client, mock_inorbit_api, mock_sleep
+):
+    """A message handler that raises must NOT propagate out of _on_message.
+
+    _on_message runs on paho's network loop thread; an exception escaping it
+    kills that thread, which is never restarted, so the session silently wedges
+    (is_connected() can keep reporting True). The error must be logged and
+    swallowed instead of re-raised.
+    """
+    robot_session = RobotSession(
+        robot_id="id_123", robot_name="name_123", api_key="apikey_123"
+    )
+
+    def boom(_payload):
+        raise RuntimeError("handler blew up")
+
+    robot_session.message_handlers["my/sub"] = boom
+
+    msg = MQTTMessage(topic=b"r/id_123/my/sub")
+    msg.payload = b"payload"
+
+    # Must not raise.
+    robot_session._on_message(None, None, msg)
+
+
+def test_keepalive_default_is_60_seconds(
+    mock_mqtt_client, mock_inorbit_api, mock_sleep
+):
+    """Default MQTT keepalive should be a non-aggressive 60s, not 10s."""
+    robot_session = RobotSession(
+        robot_id="id_123", robot_name="name_123", api_key="apikey_123"
+    )
+    assert robot_session.keepalive_secs == 60
+
+
 @pytest.mark.parametrize(
     "test_input,expected",
     [


### PR DESCRIPTION
## Summary

paho dispatches user callbacks (`on_message`, `on_connect`, `on_disconnect`, …) **on the network loop thread**, and with `suppress_exceptions=False` (paho's default) it re-raises any exception that escapes a callback (`client.py`: `if not self.suppress_exceptions: raise`). That re-raise unwinds `loop_forever`, so the loop thread **exits permanently** — it is never restarted, yet `is_connected()` can keep reporting `True`. The result is a session that looks connected but silently drops every QoS-0 publish (pose, key-values) until the process is restarted.

This hardens `RobotSession` so a callback error can't wedge the session — and stays *visible* rather than merely suppressed — and reduces spurious keepalive-timeout disconnects.

## Changes

- **`_guard_callback(name)` wraps each registered callback** (`on_connect`, `on_message`, `on_disconnect`): an exception is logged with a traceback through the session logger (tagged with the callback name) and swallowed, so it never reaches paho's re-raise path on the loop thread. This is the primary mechanism and keeps the error observable.
- **`client.enable_logger(self.logger)`** — without it, paho's own `"Caught exception in …"` message (emitted when `suppress_exceptions` swallows) went nowhere; now paho's internal logs are surfaced.
- **`client.suppress_exceptions = True`** — catch-all net for any callback path not wrapped above (and future ones).
- **`_on_message` no longer re-raises** — logs with traceback (topic context) and swallows.
- **Keepalive default 10s → 60s** — 10s trips spurious "keep alive timeout" disconnects whenever the loop thread is briefly busy. Still overridable via the `keepalive_secs` kwarg.

### Note on the keepalive change

`is_connected()` is a cached state flag updated by the loop thread; a silent/black-hole link is only detected via keepalive, i.e. up to ~2× keepalive. Raising the default to 60s trades slower silent-drop detection (now up to ~120s, was ~20s) for far fewer false-positive disconnects. Latency-sensitive callers can pass a smaller `keepalive_secs`.

## Test plan

- 4 new tests in `test_robot_session_callbacks.py`: handler error doesn't propagate out of `_on_message`; keepalive default is 60s; `_guard_callback` logs-and-swallows; `enable_logger` is wired.
- Suite: **122 passed**. Pre-existing failures unrelated to this change: `test_metrics` (requires the `opentelemetry` extra) and `test_video::test_robot_session_register_camera` (OpenCV camera) — both fail identically with these edits reverted.
- `flake8` clean, `black --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
