### PR TITLE
Reopen a dropped video stream instead of spinning on a dead capture

### DIFF
--- a/inorbit_edge/tests/test_video.py
+++ b/inorbit_edge/tests/test_video.py
@@ -4,6 +4,8 @@
 import threading
 import time
 
+import cv2
+
 from inorbit_edge.robot import RobotSession
 from inorbit_edge.video import CameraStreamer, OpenCVCamera
 from inorbit_edge.robot import INORBIT_MODULE_CAMERAS
@@ -39,6 +41,74 @@ class FakeCamera:
 
     def get_frame_jpg(self):
         return None, 0, 0, 0
+
+
+class FakeCapture:
+    """Minimal cv2.VideoCapture double that counts grabs."""
+
+    def __init__(self, grab_ok=False):
+        self.grab_ok = grab_ok
+        self.grabs = 0
+        self.released = False
+
+    def grab(self):
+        self.grabs += 1
+        return self.grab_ok
+
+    def retrieve(self):
+        return False, None
+
+    def release(self):
+        self.released = True
+
+
+def test_failed_grab_reopens_the_capture_without_spinning(mocker):
+    """A dead stream must be backed off and rebuilt, not spun on."""
+    camera = OpenCVCamera("rtsp://camera.invalid/stream", rate=1)
+    camera.REOPEN_BACKOFF_SECONDS = (0.05,)
+    captures = []
+
+    def fake_open_capture():
+        captures.append(FakeCapture(grab_ok=False))
+        return captures[-1]
+
+    mocker.patch.object(camera, "_open_capture", side_effect=fake_open_capture)
+
+    camera.open()
+    try:
+        time.sleep(0.3)
+    finally:
+        camera.close()
+
+    # Unpaced, a failing grab() runs hundreds of thousands of times in 0.3s and
+    # pegs a core; with the backoff it stays in the single digits per capture.
+    assert sum(capture.grabs for capture in captures) < 25
+    assert len(captures) > 1, "capture was never reopened"
+    assert captures[0].released
+
+
+def test_get_frame_jpg_returns_no_frame_while_the_capture_is_reopening():
+    camera = OpenCVCamera("rtsp://camera.invalid/stream", rate=1)
+
+    jpg, width, height, _ts = camera.get_frame_jpg()
+
+    assert jpg is None and (width, height) == (0, 0)
+
+
+def test_url_sources_request_the_ffmpeg_backend(mocker):
+    """OPENCV_FFMPEG_CAPTURE_OPTIONS only applies to the FFmpeg backend."""
+    video_capture = mocker.patch("cv2.VideoCapture")
+
+    OpenCVCamera("rtsp://camera.invalid/stream")._open_capture()
+    assert video_capture.call_args.args[1] == cv2.CAP_FFMPEG
+
+    OpenCVCamera("/dev/video0")._open_capture()
+    assert video_capture.call_args.args[1] == cv2.CAP_ANY
+
+    OpenCVCamera(
+        "rtsp://camera.invalid/stream", api_preference=cv2.CAP_GSTREAMER
+    )._open_capture()
+    assert video_capture.call_args.args[1] == cv2.CAP_GSTREAMER
 
 
 def test_robot_session_register_camera(

--- a/inorbit_edge/video.py
+++ b/inorbit_edge/video.py
@@ -55,9 +55,26 @@ def convert_frame(frame, width, height, scaling, quality=25):
 
 
 class OpenCVCamera(Camera):
-    """Camera implementation backed up by OpenCV"""
+    """Camera implementation backed up by OpenCV
 
-    def __init__(self, video_url, rate=10, scaling=0.3, quality=35):
+    A stream that goes away (camera reboot, network blip, RTSP session timeout)
+    is reopened with backoff, so video comes back without restarting the
+    connector.
+
+    For URL sources the FFmpeg backend is requested explicitly, because
+    automatic backend selection may pick another one and silently ignore
+    ``OPENCV_FFMPEG_CAPTURE_OPTIONS`` -- where deployments set the RTSP
+    transport and, importantly, the socket timeout that bounds a stalled read
+    (``rtsp_transport;tcp|timeout;3000000``). Without a timeout OpenCV waits on
+    its 30s watchdog before a dead stream is even noticed.
+    """
+
+    #: Delay before each reopen attempt, indexed by consecutive failed grabs.
+    REOPEN_BACKOFF_SECONDS = (0.5, 1.0, 2.0, 5.0, 10.0)
+
+    def __init__(
+        self, video_url, rate=10, scaling=0.3, quality=35, api_preference=None
+    ):
         # Cast to string to support URL objects
         self.video_url = str(video_url)
         self.capture = None
@@ -68,12 +85,24 @@ class OpenCVCamera(Camera):
         self.rate = rate
         self.scaling = scaling
         self.quality = quality
+        self.api_preference = api_preference
+        # Set by close() so a capture thread waiting out a reopen backoff wakes
+        # up immediately instead of holding up teardown.
+        self._closing = threading.Event()
+
+    def _open_capture(self):
+        """Return a new ``cv2.VideoCapture`` for this camera's source."""
+        preference = self.api_preference
+        if preference is None:
+            preference = cv2.CAP_FFMPEG if "://" in self.video_url else cv2.CAP_ANY
+        return cv2.VideoCapture(self.video_url, preference)
 
     def open(self):
         """Opens the capturing device / stream"""
+        self._closing.clear()
         with self.capture_mutex:
             if self.capture is None:
-                self.capture = cv2.VideoCapture(self.video_url)
+                self.capture = self._open_capture()
             if not self.running:
                 self.running = True
                 self.capture_thread = threading.Thread(target=self._run, daemon=True)
@@ -82,6 +111,7 @@ class OpenCVCamera(Camera):
     def close(self):
         """Closes the capturing device / stream"""
         self.running = False
+        self._closing.set()
 
         if self.capture_thread is not None:
             self.logger.info("Waiting for the capture thread to finish")
@@ -96,6 +126,9 @@ class OpenCVCamera(Camera):
         """Returns the latest frame captured by the camera as JPG"""
         ts = time.time() * 1000
         with self.capture_mutex:
+            if self.capture is None:
+                # No capture between a failed grab and its reopen
+                return None, 0, 0, ts
             # decode the latest grabbed frame
             ret, frame = self.capture.retrieve()
             if not ret:
@@ -107,13 +140,50 @@ class OpenCVCamera(Camera):
 
     def _run(self):
         """Thread to grab always the most recent frame"""
+        failures = 0
         while self.running:
-            with self.capture_mutex:
-                try:
+            try:
+                with self.capture_mutex:
                     # Try to grab always the latest frame
-                    self.capture.grab()
-                except Exception as e:
-                    self.logger.error(f"Failed to grab video frame {e}")
+                    grabbed = self.capture is not None and self.capture.grab()
+            except Exception as e:
+                self.logger.error(f"Failed to grab video frame {e}")
+                grabbed = False
+            if grabbed:
+                if failures:
+                    self.logger.info(
+                        f"Video stream recovered after {failures} failed grabs"
+                    )
+                    failures = 0
+                continue
+            # A grab against a dead stream fails immediately, so without a
+            # reopen this loop spins at 100% of a core for as long as the stream
+            # stays down -- and video never comes back, because nothing rebuilds
+            # the capture.
+            failures += 1
+            self._reopen(failures)
+
+    def _reopen(self, failures):
+        """Release and rebuild the capture, backing off first"""
+        if failures == 1:
+            self.logger.warning(
+                "Video stream unavailable; reopening with backoff up to "
+                f"{self.REOPEN_BACKOFF_SECONDS[-1]:.0f}s"
+            )
+        with self.capture_mutex:
+            if self.capture is not None:
+                self.capture.release()
+                self.capture = None
+        index = min(failures, len(self.REOPEN_BACKOFF_SECONDS)) - 1
+        if self._closing.wait(self.REOPEN_BACKOFF_SECONDS[index]) or not self.running:
+            return
+        try:
+            capture = self._open_capture()
+        except Exception as e:
+            self.logger.error(f"Failed to reopen video stream {e}")
+            return
+        with self.capture_mutex:
+            self.capture = capture
 
 
 class CameraStreamer:


### PR DESCRIPTION
`OpenCVCamera._run()` calls `grab()` in a tight loop and ignores the result. When the stream goes away — camera reboot, network blip, RTSP session timeout — every `grab()` returns immediately, so the capture thread **spins at 100% of a core** (measured **140%** on 3.1.0, since `get_frame_jpg()` then fights it for `capture_mutex`) and **video never comes back**: nothing rebuilds the capture, so only a module unload/load or a process restart recovers it.

- `_run()` checks `grab()`'s result and, on failure, releases and rebuilds the capture with bounded backoff (0.5s → 10s), logging the first failure of a streak and the recovery.
- The backoff waits on a `_closing` Event set by `close()`, so teardown is never delayed by a pending retry.
- `get_frame_jpg()` returns no frame while the capture is being rebuilt instead of raising on a `None` capture.
- URL sources request `cv2.CAP_FFMPEG` explicitly (overridable via the new `api_preference` kwarg): with automatic selection OpenCV may ignore `OPENCV_FFMPEG_CAPTURE_OPTIONS`, where deployments set the RTSP transport and the socket timeout that bounds a stalled read.

Same dead stream after: 0.6% of a core, and video resumes on its own.

Tests: 3 new cases in `test_video.py`. Suite green, flake8/black clean.

First of a train: #105 recovery → #106 decode throttling → #107 staleness → #108 health counters.