### PR TITLE
Stop serving a stale video frame as if the stream were live

### DIFF
--- a/inorbit_edge/tests/test_video.py
+++ b/inorbit_edge/tests/test_video.py
@@ -116,6 +116,19 @@ def test_frames_are_decoded_at_the_publish_rate_not_the_stream_rate(mocker):
     assert capture.retrieves == retrieves_after_publishing
 
 
+def test_frame_older_than_the_staleness_window_is_not_served():
+    """A frozen frame must not be published as if the stream were live."""
+    frame = numpy.zeros((16, 16, 3), dtype=numpy.uint8)
+    camera = OpenCVCamera("rtsp://camera.invalid/stream", rate=1, scaling=0.5)
+    camera._frame = (frame, time.monotonic() - camera.stale_frame_seconds - 1)
+
+    assert camera.get_frame_jpg()[0] is None
+
+    # Opting out keeps the old behaviour of always serving the last frame.
+    camera.stale_frame_seconds = None
+    assert camera.get_frame_jpg()[0] is not None
+
+
 def test_get_frame_jpg_returns_no_frame_while_the_capture_is_reopening():
     camera = OpenCVCamera("rtsp://camera.invalid/stream", rate=1)
 

--- a/inorbit_edge/tests/test_video.py
+++ b/inorbit_edge/tests/test_video.py
@@ -125,8 +125,22 @@ def test_frame_older_than_the_staleness_window_is_not_served():
     assert camera.get_frame_jpg()[0] is None
 
     # Opting out keeps the old behaviour of always serving the last frame.
-    camera.stale_frame_seconds = None
+    camera.stale_frame_seconds = float("inf")
     assert camera.get_frame_jpg()[0] is not None
+
+
+def test_the_staleness_window_follows_the_publish_rate():
+    """A slow rate must not have every frame withheld as stale."""
+    # One frame every 10s: 3s after the last one nothing is wrong yet.
+    assert OpenCVCamera("rtsp://x/y", rate=0.1).stale_frame_seconds == 30.0
+    assert OpenCVCamera("rtsp://x/y", rate=1).stale_frame_seconds == 3.0
+    # Fast rates are floored, so jitter alone does not withhold frames.
+    assert OpenCVCamera("rtsp://x/y", rate=30).stale_frame_seconds == 1.0
+    # An explicit window always wins.
+    assert (
+        OpenCVCamera("rtsp://x/y", rate=1, stale_frame_seconds=0.5).stale_frame_seconds
+        == 0.5
+    )
 
 
 def test_get_frame_jpg_returns_no_frame_while_the_capture_is_reopening():

--- a/inorbit_edge/video.py
+++ b/inorbit_edge/video.py
@@ -164,9 +164,11 @@ class OpenCVCamera(Camera):
         frame = self._frame
         if frame is None:
             return None, 0, 0, ts
-        if time.monotonic() - frame[1] > self.stale_frame_seconds:
+        age = time.monotonic() - frame[1]
+        if age > self.stale_frame_seconds:
             # The stream stopped delivering. Publishing this again would show a
             # frozen image as if it were live -- report no frame instead.
+            self.logger.debug(f"Withholding a video frame {age:.1f}s old")
             return None, 0, 0, ts
         height, width = frame[0].shape[:2]
         jpg, w, h = convert_frame(frame[0], width, height, self.scaling, self.quality)

--- a/inorbit_edge/video.py
+++ b/inorbit_edge/video.py
@@ -59,7 +59,10 @@ class OpenCVCamera(Camera):
 
     A stream that goes away (camera reboot, network blip, RTSP session timeout)
     is reopened with backoff, so video comes back without restarting the
-    connector.
+    connector. While it is down, frames older than ``stale_frame_seconds`` are
+    not served -- the platform shows no video rather than a frozen frame that
+    looks live. Pass ``stale_frame_seconds=None`` to always serve the last
+    decoded frame.
 
     For URL sources the FFmpeg backend is requested explicitly, because
     automatic backend selection may pick another one and silently ignore
@@ -73,7 +76,13 @@ class OpenCVCamera(Camera):
     REOPEN_BACKOFF_SECONDS = (0.5, 1.0, 2.0, 5.0, 10.0)
 
     def __init__(
-        self, video_url, rate=10, scaling=0.3, quality=35, api_preference=None
+        self,
+        video_url,
+        rate=10,
+        scaling=0.3,
+        quality=35,
+        api_preference=None,
+        stale_frame_seconds=3.0,
     ):
         # Cast to string to support URL objects
         self.video_url = str(video_url)
@@ -86,6 +95,7 @@ class OpenCVCamera(Camera):
         self.scaling = scaling
         self.quality = quality
         self.api_preference = api_preference
+        self.stale_frame_seconds = stale_frame_seconds
         # Set by close() so a capture thread waiting out a reopen backoff wakes
         # up immediately instead of holding up teardown.
         self._closing = threading.Event()
@@ -137,6 +147,13 @@ class OpenCVCamera(Camera):
         ts = time.time() * 1000
         frame = self._frame
         if frame is None:
+            return None, 0, 0, ts
+        if (
+            self.stale_frame_seconds is not None
+            and time.monotonic() - frame[1] > self.stale_frame_seconds
+        ):
+            # The stream stopped delivering. Publishing this again would show a
+            # frozen image as if it were live -- report no frame instead.
             return None, 0, 0, ts
         height, width = frame[0].shape[:2]
         jpg, w, h = convert_frame(frame[0], width, height, self.scaling, self.quality)

--- a/inorbit_edge/video.py
+++ b/inorbit_edge/video.py
@@ -61,8 +61,10 @@ class OpenCVCamera(Camera):
     is reopened with backoff, so video comes back without restarting the
     connector. While it is down, frames older than ``stale_frame_seconds`` are
     not served -- the platform shows no video rather than a frozen frame that
-    looks live. Pass ``stale_frame_seconds=None`` to always serve the last
-    decoded frame.
+    looks live. That window defaults to three publish periods (never under
+    ``MIN_STALE_FRAME_SECONDS``), so it scales with ``rate``: 1s at 10 fps, 3s
+    at 1 fps, 30s at one frame every 10s. Pass a number to set it explicitly, or
+    ``float("inf")`` to always serve the last decoded frame.
 
     For URL sources the FFmpeg backend is requested explicitly, because
     automatic backend selection may pick another one and silently ignore
@@ -74,6 +76,13 @@ class OpenCVCamera(Camera):
 
     #: Delay before each reopen attempt, indexed by consecutive failed grabs.
     REOPEN_BACKOFF_SECONDS = (0.5, 1.0, 2.0, 5.0, 10.0)
+    #: Default staleness window, in publish periods: a frame is expected every
+    #: ``1 / rate`` seconds, so three periods without a fresh one means the
+    #: stream stopped rather than lagged.
+    STALE_FRAME_PERIODS = 3
+    #: Floor for the derived window: without it a fast publish rate would
+    #: withhold frames on ordinary jitter (rate=30 alone gives 0.1s).
+    MIN_STALE_FRAME_SECONDS = 1.0
 
     def __init__(
         self,
@@ -82,7 +91,7 @@ class OpenCVCamera(Camera):
         scaling=0.3,
         quality=35,
         api_preference=None,
-        stale_frame_seconds=3.0,
+        stale_frame_seconds=None,
     ):
         # Cast to string to support URL objects
         self.video_url = str(video_url)
@@ -95,7 +104,14 @@ class OpenCVCamera(Camera):
         self.scaling = scaling
         self.quality = quality
         self.api_preference = api_preference
-        self.stale_frame_seconds = stale_frame_seconds
+        self.stale_frame_seconds = (
+            stale_frame_seconds
+            if stale_frame_seconds is not None
+            else max(
+                self.MIN_STALE_FRAME_SECONDS,
+                self.STALE_FRAME_PERIODS / max(rate, 0.01),
+            )
+        )
         # Set by close() so a capture thread waiting out a reopen backoff wakes
         # up immediately instead of holding up teardown.
         self._closing = threading.Event()
@@ -148,10 +164,7 @@ class OpenCVCamera(Camera):
         frame = self._frame
         if frame is None:
             return None, 0, 0, ts
-        if (
-            self.stale_frame_seconds is not None
-            and time.monotonic() - frame[1] > self.stale_frame_seconds
-        ):
+        if time.monotonic() - frame[1] > self.stale_frame_seconds:
             # The stream stopped delivering. Publishing this again would show a
             # frozen image as if it were live -- report no frame instead.
             return None, 0, 0, ts


### PR DESCRIPTION
Stacked on #106.

`get_frame_jpg()` re-encoded the last decoded frame for as long as the stream stayed down, so the platform kept showing a frozen image that looked live — the worst failure mode for a safety camera, and it hides the outage from whoever is watching.

Frames older than the new `stale_frame_seconds` (default 3s, ~3× the age a frame reaches at the default publish rate) are no longer served, so the platform shows no video instead. `stale_frame_seconds=None` restores the old behaviour.

Behaviour change worth calling out in release notes.

Tests: 1 new case. Suite green, flake8/black clean.