### PR TITLE
Bump version: 3.1.0 → 3.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 commit = true
-current_version = 3.1.0
+current_version = 3.2.0
 tag = true
 
 [bumpversion:file(version):setup.py]

--- a/inorbit_edge/__init__.py
+++ b/inorbit_edge/__init__.py
@@ -6,7 +6,7 @@ __author__ = "InOrbit"
 __email__ = "support@inorbit.ai"
 # Do not edit this string manually, always use bumpversion
 # Details in CONTRIBUTING.md
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 
 def get_module_version():

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import os
 from setuptools import find_packages, setup
 
 # Do not edit manually, always use bumpversion (see CONTRIBUTING.rst)
-VERSION = "3.1.0"
+VERSION = "3.2.0"
 
 GITHUB_ORG = "https://github.com/inorbit-ai"
 GITHUB_REPO = f"{GITHUB_ORG}/edge-sdk-python"
@@ -48,7 +48,7 @@ setup(
     ],
     description="InOrbit Edge SDK for Python",
     # Do not edit manually, always use bumpversion (see CONTRIBUTING.rst)
-    download_url=f"{GITHUB_REPO}/archive/refs/tags/v3.1.0.zip",
+    download_url=f"{GITHUB_REPO}/archive/refs/tags/v3.2.0.zip",
     extras_require={
         "video": requirements["video"],
         "telemetry": requirements["telemetry"],


### PR DESCRIPTION
`bump2version minor` (no tag — see below). Releases the video capture work merged since 3.1.0:

- **#105** — a dropped stream is reopened with backoff instead of spinning the capture thread on a dead handle at 100% of a core, so video returns without restarting the connector. URL sources now request `cv2.CAP_FFMPEG` explicitly, so `OPENCV_FFMPEG_CAPTURE_OPTIONS` (RTSP transport, socket timeout) actually applies.
- **#109** — the grab loop no longer holds `capture_mutex` (it was starving `get_frame_jpg`), and frames are converted to BGR at the publish rate rather than per grab.
- **#107** — **behaviour change:** frames older than the staleness window are no longer served, so a stream that died shows no video instead of a frozen picture that looks live. The window defaults to three publish periods (1s at 10 fps, 3s at 1 fps, 30s at 0.1 fps) with a 1s floor; `stale_frame_seconds` overrides it and `float("inf")` restores the old behaviour.
- **#108** — a per-minute capture health line (`grabbed`/`served`/`stale`/`reopens`) plus `video_frames_grabbed`, `video_frames_stale` and `video_capture_reopens` OTEL counters, and the README's first camera-streaming section.

Release notes should call out #107: a consumer that relied on the last frame being re-served forever needs `stale_frame_seconds=float("inf")`.

**Tagging:** run with `--no-tag` because past bumps were squash-merged (`Bump version: 3.0.0 → 3.1.0 (#104)`), which discards the branch commit a local tag would point at. After merge, on updated `main`:

```bash
git tag v3.2.0 && git push --tags
```

The squashed commit message still contains "Bump version", so the PyPI publish job in `build-main.yml` fires on merge; the tag only keeps `setup.py`'s `download_url` resolvable.